### PR TITLE
Wrap transfer, transferFrom and approve in require

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -133,14 +133,14 @@ contract Funds is DSMath {
         funds[fund].agent = agent_;
 
         if (tokas[address(tok_)] == false) {
-            tok_.approve(address(loans), 2**256-1);
+            require(tok_.approve(address(loans), 2**256-1));
             tokas[address(tok_)] = true;
         }
     }
 
     function push(bytes32 fund, uint256 amt) public { // Push funds to Loan Fund
         // require(msg.sender == own(fund) || msg.sender == address(loans)); // NOTE: this require is not necessary. Anyone can fund someone elses loan fund
-        funds[fund].tok.transferFrom(msg.sender, address(this), amt);
+        require(funds[fund].tok.transferFrom(msg.sender, address(this), amt));
         funds[fund].bal = add(funds[fund].bal, amt);
     }
 
@@ -201,7 +201,7 @@ contract Funds is DSMath {
     function pull(bytes32 fund, uint256 amt) public { // Pull funds from Loan Fund
         require(msg.sender == own(fund));
         require(bal(fund)  >= amt);
-        funds[fund].tok.transfer(own(fund), amt);
+        require(funds[fund].tok.transfer(own(fund), amt));
         funds[fund].bal = sub(funds[fund].bal, amt);
     }
 

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -218,7 +218,7 @@ contract Loans is DSMath {
         sechs[loan].set    = false;
 
         if (fundi_ != bytes32(0) && tokas[address(tok_)] == false) {
-            tok_.approve(address(funds), 2**256-1);
+            require(tok_.approve(address(funds), 2**256-1));
             tokas[address(tok_)] = true;
         }
     }
@@ -247,7 +247,7 @@ contract Loans is DSMath {
 	function push(bytes32 loan) public { // Fund Loan
 		require(sechs[loan].set);
     	require(bools[loan].pushed == false);
-    	tokes[loan].transferFrom(msg.sender, address(this), prin(loan));
+    	require(tokes[loan].transferFrom(msg.sender, address(this), prin(loan)));
     	bools[loan].pushed = true;
     }
 
@@ -263,7 +263,7 @@ contract Loans is DSMath {
     	require(bools[loan].pushed == true);
     	require(bools[loan].marked == true);
     	require(sha256(abi.encodePacked(secA1)) == sechs[loan].sechA1);
-    	tokes[loan].transfer(loans[loan].bor, prin(loan));
+    	require(tokes[loan].transfer(loans[loan].bor, prin(loan)));
     	bools[loan].taken = true;
     }
 
@@ -275,7 +275,7 @@ contract Loans is DSMath {
     	require(now                       <= loans[loan].loex);
     	require(add(amt, backs[loan])     <= owed(loan));
 
-    	tokes[loan].transferFrom(loans[loan].bor, address(this), amt);
+    	require(tokes[loan].transferFrom(loans[loan].bor, address(this), amt));
     	backs[loan] = add(amt, backs[loan]);
     	if (backs[loan] == owed(loan)) {
     		bools[loan].paid = true;
@@ -288,7 +288,7 @@ contract Loans is DSMath {
     	require(now              >  acex(loan));
     	require(bools[loan].paid == true);
     	require(msg.sender       == loans[loan].bor);
-    	tokes[loan].transfer(loans[loan].bor, owed(loan));
+    	require(tokes[loan].transfer(loans[loan].bor, owed(loan)));
     }
 
     function pull(bytes32 loan, bytes32 sec) public {
@@ -302,14 +302,14 @@ contract Loans is DSMath {
         require(now                             <= acex(loan));
         require(bools[loan].sale                == false);
         if (bools[loan].taken == false) {
-            tokes[loan].transfer(loans[loan].lend, loans[loan].prin);
+            require(tokes[loan].transfer(loans[loan].lend, loans[loan].prin));
         } else if (bools[loan].taken == true) {
             if (fundi[loan] == bytes32(0) || !fund) {
-                tokes[loan].transfer(loans[loan].lend, lent(loan));
+                require(tokes[loan].transfer(loans[loan].lend, lent(loan)));
             } else {
                 funds.push(fundi[loan], lent(loan));
             }
-            tokes[loan].transfer(loans[loan].agent, lfee(loan));
+            require(tokes[loan].transfer(loans[loan].agent, lfee(loan)));
         }
         bools[loan].off = true;
     }
@@ -337,7 +337,7 @@ contract Loans is DSMath {
             require(!sales.taken(sales.salel(loan, sales.next(loan) - 1))); // Can only start auction again if previous auction bid wasn't taken
 		}
 		sale = sales.open(loan, loans[loan].bor, loans[loan].lend, loans[loan].agent, sechi(loan, 'A'), sechi(loan, 'B'), sechi(loan, 'C'), tokes[loan], vares[loan]);
-        tokes[loan].transfer(address(sales), back(loan));
+        require(tokes[loan].transfer(address(sales), back(loan)));
 		bools[loan].sale = true;
     }
 }

--- a/contracts/Sales.sol
+++ b/contracts/Sales.sol
@@ -198,9 +198,9 @@ contract Sales is DSMath { // Auctions
     		require(amt > rmul(sales[sale].bid, vares[sale].MINBI())); // Make sure next bid is at least 0.5% more than the last bid
     	}
 
-    	tokes[sale].transferFrom(msg.sender, address(this), amt);
+    	require(tokes[sale].transferFrom(msg.sender, address(this), amt));
     	if (sales[sale].bid > 0) {
-    		tokes[sale].transfer(sales[sale].bidr, sales[sale].bid);
+    		require(tokes[sale].transfer(sales[sale].bidr, sales[sale].bid));
     	}
     	sales[sale].bidr = msg.sender;
     	sales[sale].bid  = amt;
@@ -262,15 +262,15 @@ contract Sales is DSMath { // Auctions
 		require(sha256(abi.encodePacked(sechs[sale].secD)) == sechs[sale].sechD);
 
         if (sales[sale].bid > (loans.dedu(sales[sale].loani))) {
-            tokes[sale].transfer(sales[sale].lend, loans.lentb(sales[sale].loani));
+            require(tokes[sale].transfer(sales[sale].lend, loans.lentb(sales[sale].loani)));
             if (agent(sale) != address(0)) {
-                tokes[sale].transfer(sales[sale].agent, loans.lfee(sales[sale].loani));
+                require(tokes[sale].transfer(sales[sale].agent, loans.lfee(sales[sale].loani)));
             }
-            tokes[sale].approve(address(med), loans.lpen(sales[sale].loani));
+            require(tokes[sale].approve(address(med), loans.lpen(sales[sale].loani)));
             med.push(loans.lpen(sales[sale].loani), tokes[sale]);
-            tokes[sale].transfer(sales[sale].bor, add(sub(sales[sale].bid, loans.dedub(sales[sale].loani)), loans.back(sales[sale].loani)));
+            require(tokes[sale].transfer(sales[sale].bor, add(sub(sales[sale].bid, loans.dedub(sales[sale].loani)), loans.back(sales[sale].loani))));
         } else {
-            tokes[sale].transfer(sales[sale].lend, sales[sale].bid);
+            require(tokes[sale].transfer(sales[sale].lend, sales[sale].bid));
         }
         sales[sale].taken = true;
 	}
@@ -282,9 +282,9 @@ contract Sales is DSMath { // Auctions
 		require(!hasSecs(sale));
 		require(sha256(abi.encodePacked(sechs[sale].secD)) != sechs[sale].sechD);
 		require(sales[sale].bid > 0);
-		tokes[sale].transfer(sales[sale].bidr, sales[sale].bid);
+		require(tokes[sale].transfer(sales[sale].bidr, sales[sale].bid));
         if (next(sales[sale].loani) == 3) {
-            tokes[sale].transfer(sales[sale].bor, loans.back(sales[sale].loani));
+            require(tokes[sale].transfer(sales[sale].bor, loans.back(sales[sale].loani)));
         }
         sales[sale].off = true;
 	}


### PR DESCRIPTION
Wrap transfer, transferFrom and approve in require

ERC20's `transfer`, `transferFrom`, and `approve` functions return a boolean indicating success. Many implementations revert failed transfers, but certainly not all do. Because of this, the return value must be checked. Otherwise it may seem that the call succeeded when it actually failed.