### PR TITLE
Fix reentrancy attack Funds.pull vulnerability

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -201,8 +201,8 @@ contract Funds is DSMath {
     function pull(bytes32 fund, uint256 amt) public { // Pull funds from Loan Fund
         require(msg.sender == own(fund));
         require(bal(fund)  >= amt);
-        require(funds[fund].tok.transfer(own(fund), amt));
         funds[fund].bal = sub(funds[fund].bal, amt);
+        require(funds[fund].tok.transfer(own(fund), amt));
     }
 
     function calc(uint256 amt, uint256 rate, uint256 lodu) public pure returns (uint256) { // Calculate interest


### PR DESCRIPTION
Fix reentrancy attack `Funds.pull` vulnerability

If an ERC 223 or ERC 777 token (or another token that calls out to the sender or recipient during transfer) is used as the token, a reentrancy call could be made to `Funds.pull`, causing funds to be transferred again. This can be called repeatedly until `Funds` contract has been drained. 

This PR solves this issue by moving the balance update above the transfer.