### PR TITLE
Fix Loans setSechs off by one vulnerability

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -234,11 +234,11 @@ contract Loans is DSMath {
 		require(!sechs[loan].set);
 		require(msg.sender == loans[loan].bor || msg.sender == loans[loan].lend || msg.sender == address(funds));
 		sechs[loan].sechA1 = bsechs[0];
-		sechs[loan].sechAS = [ bsechs[0], bsechs[1], bsechs[2] ];
+		sechs[loan].sechAS = [ bsechs[1], bsechs[2], bsechs[3] ];
 		sechs[loan].sechB1 = lsechs[0];
-		sechs[loan].sechBS = [ lsechs[0], lsechs[1], lsechs[2] ];
+		sechs[loan].sechBS = [ lsechs[1], lsechs[2], lsechs[3] ];
 		sechs[loan].sechC1 = asechs[0];
-		sechs[loan].sechCS = [ asechs[0], asechs[1], asechs[2] ];
+		sechs[loan].sechCS = [ asechs[1], asechs[2], asechs[3] ];
 		loans[loan].bpubk  = bpubk_;
 		loans[loan].lpubk  = lpubk_;
         sechs[loan].set    = true;

--- a/test/loans.js
+++ b/test/loans.js
@@ -225,8 +225,8 @@ contract("Loans", accounts => {
 
       await time.increase(1800 + 1)
 
-      await this.sales.sec(this.sale, lendSecs[0])
-      await this.sales.sec(this.sale, borSecs[0], { from: borrower })
+      await this.sales.sec(this.sale, lendSecs[1])
+      await this.sales.sec(this.sale, borSecs[1], { from: borrower })
       await this.sales.sec(this.sale, bidrSecs[1])
 
       await this.sales.take(this.sale)

--- a/test/sales.js
+++ b/test/sales.js
@@ -174,8 +174,8 @@ contract("Sales", accounts => {
 
       await time.increase(toSecs({minutes: 2}))
 
-      await this.sales.sec(this.sale, lendSecs[0])
-      await this.sales.sec(this.sale, borSecs[0], { from: borrower })
+      await this.sales.sec(this.sale, lendSecs[1])
+      await this.sales.sec(this.sale, borSecs[1], { from: borrower })
       await this.sales.sec(this.sale, bidrSecs[1])
 
       await this.sales.take(this.sale)


### PR DESCRIPTION
Fix Loans `setSechs` off by one vulnerability

```
sechs[loan].sechA1 = bsechs[0];
sechs[loan].sechAS = [ bsechs[0], bsechs[1], bsechs[2] ];
sechs[loan].sechB1 = lsechs[0];
sechs[loan].sechBS = [ lsechs[0], lsechs[1], lsechs[2] ];
sechs[loan].sechC1 = asechs[0];
sechs[loan].sechCS = [ asechs[0], asechs[1], asechs[2] ];
```

For each participant A, B, and C, four secret hashes are passed in, but the last one is unused and the first one is used twice. A reused secret is often catastrophic, as it means the secret is revealed before the appropriate time.

This bug can also go unnoticed by the participants, simply leading to them being unable to complete the loan process.

This PR fixes this problem by increasing `sechAS`, `sechBS`, `sechCS` to ensure secrets aren't reused. 