### PR TITLE
Fix mishandled partial repayments

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -337,7 +337,7 @@ contract Loans is DSMath {
             require(!sales.taken(sales.salel(loan, sales.next(loan) - 1))); // Can only start auction again if previous auction bid wasn't taken
 		}
 		sale = sales.open(loan, loans[loan].bor, loans[loan].lend, loans[loan].agent, sechi(loan, 'A'), sechi(loan, 'B'), sechi(loan, 'C'), tokes[loan], vares[loan]);
-        require(tokes[loan].transfer(address(sales), back(loan)));
+        if (bools[loan].sale == false) { require(tokes[loan].transfer(address(sales), back(loan))); }
 		bools[loan].sale = true;
     }
 }


### PR DESCRIPTION
Fix mishandled partial repayments

Before a sale is started, the borrower may have already paid back part of the loan.

`tokes[loan].transfer(address(sales), back(loan))` is called every time a Sale is started with `Loans.sell`. However, since there is no check on this, it can be called up to 3 times. 

This PR fixes this problem by ensuring this transfer only occurs once. 