### PR TITLE
Fix secret reuse with Funds.sechi

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -242,8 +242,8 @@ contract Funds is DSMath {
         );
     }
 
-    function gsech(address addr) private view returns (bytes32[4] memory) { // Get 4 secrethashes for loan
-        require((sechs[addr].length - sechi[addr]) >= 4);
-        return [ sechs[addr][add(sechi[addr], 0)], sechs[addr][add(sechi[addr], 1)], sechs[addr][add(sechi[addr], 2)], sechs[addr][add(sechi[addr], 3)] ];
+    function gsech(address addr) private returns (bytes32[4] memory) { // Get 4 secrethashes for loan
+        sechi[addr] = add(sechi[addr], 4);
+        return [ sechs[addr][sub(sechi[addr], 4)], sechs[addr][sub(sechi[addr], 3)], sechs[addr][sub(sechi[addr], 2)], sechs[addr][sub(sechi[addr], 1)] ];
     }
 }


### PR DESCRIPTION
Fix secret reuse with Funds.sechi

It's important in HTLCCs that secrets are not reused. If a previously revealed secret is used for a new HTLC, the beneficiary of that HTLCC can immediately claim the funds (because the locking secret has already been revealed).

`Funds.sechi` determines which secret hashes are used to create new loans, but it is never updated, so it always has the value `0`. This means the same four secrets are reused each time: