### PR TITLE
Fix reentrancy attack vulnerability Loans.pull

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -301,6 +301,7 @@ contract Loans is DSMath {
         require(sha256(abi.encodePacked(sec)) == sechs[loan].sechB1 || sha256(abi.encodePacked(sec)) == sechs[loan].sechC1);
         require(now                             <= acex(loan));
         require(bools[loan].sale                == false);
+        bools[loan].off = true;
         if (bools[loan].taken == false) {
             require(tokes[loan].transfer(loans[loan].lend, loans[loan].prin));
         } else if (bools[loan].taken == true) {
@@ -311,7 +312,6 @@ contract Loans is DSMath {
             }
             require(tokes[loan].transfer(loans[loan].agent, lfee(loan)));
         }
-        bools[loan].off = true;
     }
 
     function sechi(bytes32 loan, bytes32 usr) private view returns (bytes32 sech) { // Get Secret Hash for Sale Index


### PR DESCRIPTION
Fix reentrancy attack vulnerability Loans.pull

Loans.pull can't be called twice because it checks !off(loan) at the top and sets `bools[loan].off = true` at the bottom, but because it has no reentrancy protection, it can be called multiple times as part of the same transaction.

This PR fixes this issue by ensuring that `bools[loan].off = true;` is set before any transfers. 