### PR TITLE
Fix reentrancy attack vulnerability Sales.take

### DIFF
--- a/contracts/Sales.sol
+++ b/contracts/Sales.sol
@@ -260,7 +260,7 @@ contract Sales is DSMath { // Auctions
 		require(now > sales[sale].salex);
 		require(hasSecs(sale));
 		require(sha256(abi.encodePacked(sechs[sale].secD)) == sechs[sale].sechD);
-
+        sales[sale].taken = true;
         if (sales[sale].bid > (loans.dedu(sales[sale].loani))) {
             require(tokes[sale].transfer(sales[sale].lend, loans.lentb(sales[sale].loani)));
             if (agent(sale) != address(0)) {
@@ -272,7 +272,6 @@ contract Sales is DSMath { // Auctions
         } else {
             require(tokes[sale].transfer(sales[sale].lend, sales[sale].bid));
         }
-        sales[sale].taken = true;
 	}
 
 	function unpush(bytes32 sale) public { // Refund Bid


### PR DESCRIPTION
### Description

This PR fixes the reentrancy attack vulnerability in `Sales.take`

Sales.take can't be called twice because it checks `!taken(sale)` at the top and sets `sales[sale].taken = true` at the bottom, but because it has no reentrancy protection, it can be called multiple times as part of the same transaction.

### Submission Checklist :pencil:

- [x] Move `sales[sale].taken = true;` above any transfers that occur
