### PR TITLE
Fix lender and borrower colluding vulnerability

### DIFF
--- a/contracts/Sales.sol
+++ b/contracts/Sales.sol
@@ -278,13 +278,11 @@ contract Sales is DSMath { // Auctions
         require(!taken(sale));
         require(!off(sale));
 		require(now > sales[sale].setex);
-		require(!hasSecs(sale));
-		require(sha256(abi.encodePacked(sechs[sale].secD)) != sechs[sale].sechD);
 		require(sales[sale].bid > 0);
+        sales[sale].off = true;
 		require(tokes[sale].transfer(sales[sale].bidr, sales[sale].bid));
         if (next(sales[sale].loani) == 3) {
             require(tokes[sale].transfer(sales[sale].bor, loans.back(sales[sale].loani)));
         }
-        sales[sale].off = true;
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes a vulnerability of lender and borrower colluding to prevent bidder from getting refund. 

In `Sales.unpush`, the high bidder can only receive a refund if the borrower and lender have not revealed their secrets:

This means that the lender and borrower can lock the high bidder's funds forever simply by revealing those secrets. This opens up a ransom opportunity:

- Alice and Bob (probably the same person), acting as borrower and lender, are conspiring to steal from David.
- They establish a loan and default.
- David is the high bidder in the liquidation option.
- When the sales expiration is reached, Alice and Bob reveal their secrets A and B to the Sales contract, but they do not move collateral to the collateral swap provider.
- David has no way to retrieve the collateral, and he has no way to receive a refund.
- Alice and Bob still have the ability to complete the sale, but they can demand that David pay a ransom first.

This PR allows the Bidder to refund the bid regardless of if the Borrower and Lender have completed the Sale. 

### Submission Checklist :pencil:

- [x] Remove necessity for Borrower/Lender secrets to be revealed in order to refund bid
