### PR TITLE
Ensure anyone can repay loan

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -275,7 +275,7 @@ contract Loans is DSMath {
     	require(now                       <= loans[loan].loex);
     	require(add(amt, backs[loan])     <= owed(loan));
 
-    	require(tokes[loan].transferFrom(loans[loan].bor, address(this), amt));
+    	require(tokes[loan].transferFrom(msg.sender, address(this), amt));
     	backs[loan] = add(amt, backs[loan]);
     	if (backs[loan] == owed(loan)) {
     		bools[loan].paid = true;


### PR DESCRIPTION
### Description

This PR fixes a bug that could enable anyone to force the Borrower to repay the loan. This PR fixes that problem by ensuring that the individual calling `pay` is in fact paying back the loan. This ensures that anyone can repay the loan. 

### Submission Checklist :pencil:

- [x] Change `loans[loan].bor` to `msg.sender` for repaying the loan 
