### PR TITLE
Reduce vulnerabilities with Funds contract init race conditions

### DIFF
--- a/test/funds.js
+++ b/test/funds.js
@@ -302,4 +302,10 @@ contract("Funds", accounts => {
       await shouldFail.reverting(this.funds.pull(this.fund, toWei('50', 'ether'), { from: agent }))
     })
   })
+
+  describe('setLoans', function() {
+    it('should not allow setLoans to be called twice', async function() {
+      await shouldFail.reverting(this.funds.setLoans(this.loans.address))
+    })
+  })
 })


### PR DESCRIPTION
### Description

This PR reduces vulnerabilities with Funds contract init race conditions. 

`setLoans` is used to set the `Loans` contract address after deployment. This PR this can only be called by the original deployer, and can only be called once. 

### Submission Checklist :pencil:

- [x] Add check to ensure `setLoans` can only be called by deployer and only called once
- [x] Add tests to ensure `setLoans` can't be called twice. 
