### PR TITLE
Ensure only lender or agent can accept or cancel a loan

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -299,6 +299,7 @@ contract Loans is DSMath {
     function pull(bytes32 loan, bytes32 sec, bool fund) public { // Accept or Cancel // Bool fund set true if lender wants fund to return to fund
         require(!off(loan));
         require(bools[loan].taken == false || bools[loan].paid == true);
+        require(msg.sender == loans[loan].lend || msg.sender == loans[loan].agent);
         require(sha256(abi.encodePacked(sec)) == sechs[loan].sechB1 || sha256(abi.encodePacked(sec)) == sechs[loan].sechC1);
         require(now                             <= acex(loan));
         require(bools[loan].sale                == false);


### PR DESCRIPTION
### Description

This PR ensures that only the `lender` or `agent` can accept or cancel a loan. 

When Bob calls `Loans.pull()` at the end of the loan period, he does so by revealing B1. This gives anyone an opportunity to front run the transaction and modify parameters being sent in, specifically the fund boolean that determines how the loan principal and interest are delivered.

### Submission Checklist :pencil:

- [x] Add `require` to ensure `Loans.pull` is called by `lender` or `agent`. 
