### PR TITLE
Remove unnecessary user supplied Currency contract

### DIFF
--- a/contracts/DSMath.sol
+++ b/contracts/DSMath.sol
@@ -28,9 +28,13 @@ contract DSMath {
         return x >= y ? x : y;
     }
 
+    uint constant COL = 10 ** 8;
     uint constant WAD = 10 ** 18;
     uint constant RAY = 10 ** 27;
 
+    function cmul(uint x, uint y) public pure returns (uint z) {
+        z = add(mul(x, y), COL / 2) / COL;
+    }
     function wmul(uint x, uint y) internal pure returns (uint z) {
         z = add(mul(x, y), WAD / 2) / WAD;
     }

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -2,7 +2,6 @@ import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 import './Loans.sol';
-import './Currency.sol';
 import './Vars.sol';
 import './DSMath.sol';
 
@@ -36,7 +35,6 @@ contract Funds is DSMath {
         address  agent; // Optional Automator Agent
         uint256  bal;   // Locked amount in fund (in TOK)
         ERC20    tok;   // Debt Token
-        Currency cur;   // Currency info
         Vars     vars;  // Variable contract
     }
 
@@ -94,10 +92,6 @@ contract Funds is DSMath {
         return address(funds[fund].tok);
     }
 
-    function cur(bytes32 fund)   public view returns (address) {
-        return address(funds[fund].cur);
-    }
-
     function vars(bytes32 fund)  public view returns (address) {
         return address(funds[fund].vars);
     }
@@ -113,7 +107,6 @@ contract Funds is DSMath {
         uint256  lfee_,  // Optional Automation Fee Rate
         address  agent_, // Optional Address Automated Agent
         ERC20    tok_,   // Debt Token
-        Currency cur_,   // Currency contract
         Vars     vars_   // Variable contract
     ) public returns (bytes32 fund) {
         fundi = add(fundi, 1);
@@ -128,7 +121,6 @@ contract Funds is DSMath {
         funds[fund].lfee  = lfee_;
         funds[fund].rat   = rat_;
         funds[fund].tok   = tok_;
-        funds[fund].cur   = cur_;
         funds[fund].vars  = vars_;
         funds[fund].agent = agent_;
 
@@ -220,7 +212,6 @@ contract Funds is DSMath {
             [ msg.sender, own(fund), funds[fund].agent],
             [ amt_, calc(amt_, lint(fund), lodu_), calc(amt_, lpen(fund), lodu_), calc(amt_, lfee(fund), lodu_), col_, funds[fund].rat],
             funds[fund].tok,
-            funds[fund].cur,
             funds[fund].vars,
             fund
         );

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -5,7 +5,6 @@ import './Funds.sol';
 import './Sales.sol';
 import './DSMath.sol';
 import './Medianizer.sol';
-import './Currency.sol';
 import './Vars.sol';
 
 pragma solidity ^0.5.8;
@@ -20,7 +19,6 @@ contract Loans is DSMath {
     mapping (bytes32 => Bools)     public bools;  // Boolean state of Loan
     mapping (bytes32 => bytes32)   public fundi;  // Mapping of Loan Index to Fund Index
     mapping (bytes32 => ERC20)     public tokes;  // Mapping of Loan index to Token contract
-    mapping (bytes32 => Currency)  public cures;  // Mapping of Loan index to Currency contract
     mapping (bytes32 => Vars)      public vares;  // Mapping of Loan index to Vars contract
     mapping (bytes32 => uint256)   public backs;  // Amount paid back in a Loan
     mapping (bytes32 => uint256)   public asaex;  // All Auction expiration
@@ -167,7 +165,7 @@ contract Loans is DSMath {
 
     function colv(bytes32 loan) public returns (uint256) { // Current Collateral Value
         uint256 val = uint(med.read());
-        return cures[loan].cmul(val, col(loan)); // Multiply value dependent on number of decimals with currency
+        return cmul(val, col(loan)); // Multiply value dependent on number of decimals with currency
     }
 
     function min(bytes32 loan) public view returns (uint256) {  // Minimum Collateral Value
@@ -194,7 +192,6 @@ contract Loans is DSMath {
         address[3] memory  usrs_,   // Borrower, Lender, Optional Automated Agent Addresses
         uint256[6] memory  vals_,   // Principal, Interest, Liquidation Penalty, Optional Automation Fee, Collaateral Amount, Liquidation Ratio
         ERC20              tok_,    // Token contract
-        Currency           cur_,    // Currency contract
         Vars               vars_,   // Variable contract
         bytes32            fundi_   // Optional Fund Index
     ) public returns (bytes32 loan) {
@@ -212,7 +209,6 @@ contract Loans is DSMath {
         loans[loan].col    = vals_[4];
         loans[loan].rat    = vals_[5];
         tokes[loan]        = tok_;
-        cures[loan]        = cur_;
         vares[loan]        = vars_;
         fundi[loan]        = fundi_;
         sechs[loan].set    = false;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,4 @@
 var ExampleCoin = artifacts.require("./ExampleDaiCoin.sol");
-var BTCCurrency = artifacts.require('./BTCCurrency.sol');
 var Medianizer = artifacts.require('./MedianizerExample.sol');
 var Vars       = artifacts.require('./VarsExample.sol');
 var Funds = artifacts.require('./Funds.sol');
@@ -9,8 +8,6 @@ var Sales = artifacts.require('./Sales.sol');
 module.exports = function(deployer) {
   deployer.then(async () => {
     await deployer.deploy(ExampleCoin);
-    await deployer.deploy(BTCCurrency);
-    var currency = await BTCCurrency.deployed();
     await deployer.deploy(Medianizer);
     var medianizer = await Medianizer.deployed();
     await deployer.deploy(Vars);

--- a/test/funds.js
+++ b/test/funds.js
@@ -11,7 +11,6 @@ const Funds = artifacts.require("./Funds.sol");
 const Loans = artifacts.require("./Loans.sol");
 const Sales = artifacts.require("./Sales.sol");
 const Med   = artifacts.require("./Medianizer.sol");
-const Cur   = artifacts.require('./BTCCurrency.sol');
 const Vars  = artifacts.require('./VarsExample.sol');
 
 const utils = require('./helpers/Utils.js');
@@ -72,7 +71,6 @@ contract("Funds", accounts => {
     this.loans = await Loans.deployed();
     this.sales = await Sales.deployed();
     this.token = await ExampleCoin.deployed();
-    this.cur   = await Cur.deployed();
     this.vars  = await Vars.deployed();
 
     const fundParams = [
@@ -86,7 +84,6 @@ contract("Funds", accounts => {
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
       agent,
       this.token.address,
-      this.cur.address,
       this.vars.address
     ]
 
@@ -197,7 +194,6 @@ contract("Funds", accounts => {
         toWei(rateToSec('0.75'), 'gether'), //  0.75%
         agent,
         this.token.address,
-        this.cur.address,
         this.vars.address
       ]
 

--- a/test/loans.js
+++ b/test/loans.js
@@ -11,7 +11,6 @@ const Funds = artifacts.require("./Funds.sol");
 const Loans = artifacts.require("./Loans.sol");
 const Sales = artifacts.require("./Sales.sol");
 const Med   = artifacts.require("./MedianizerExample.sol");
-const Cur   = artifacts.require('./BTCCurrency.sol');
 const Vars  = artifacts.require('./VarsExample.sol');
 
 const utils = require('./helpers/Utils.js');
@@ -87,7 +86,6 @@ contract("Loans", accounts => {
     this.loans = await Loans.deployed();
     this.sales = await Sales.deployed();
     this.token = await ExampleCoin.deployed();
-    this.cur   = await Cur.deployed();
     this.vars  = await Vars.deployed();
 
     this.med   = await Med.deployed();
@@ -105,7 +103,6 @@ contract("Loans", accounts => {
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
       agent,
       this.token.address,
-      this.cur.address,
       this.vars.address
     ]
 

--- a/test/sales.js
+++ b/test/sales.js
@@ -11,7 +11,6 @@ const Funds = artifacts.require("./Funds.sol");
 const Loans = artifacts.require("./Loans.sol");
 const Sales = artifacts.require("./Sales.sol");
 const Med   = artifacts.require("./MedianizerExample.sol");
-const Cur   = artifacts.require('./BTCCurrency.sol');
 const Vars  = artifacts.require('./VarsExample.sol');
 
 const utils = require('./helpers/Utils.js');
@@ -87,7 +86,6 @@ contract("Sales", accounts => {
     this.loans = await Loans.deployed();
     this.sales = await Sales.deployed();
     this.token = await ExampleCoin.deployed();
-    this.cur   = await Cur.deployed();
     this.vars  = await Vars.deployed();
 
     this.med   = await Med.deployed();
@@ -105,7 +103,6 @@ contract("Sales", accounts => {
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
       agent,
       this.token.address,
-      this.cur.address,
       this.vars.address
     ]
 


### PR DESCRIPTION
### Description

This PR removes the unnecessary Currency contract, and assumes the collateral is valued in satoshis (10 ** 8). 

If a malicious contract is used, the contract owner could manipulate this value to make a loan subject to liquidation when it shouldn't be.

### Submission Checklist :pencil:

- [x] Remove `Currency` contract
