### PR TITLE
Reduce vulnerabilities with Loans contract init race conditions

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -28,7 +28,7 @@ contract Loans is DSMath {
 
     mapping (address => bool)      public tokas;  // Is ERC20 Token Approved
 
-    bool on; // Ensure that Sales contract is created
+    address own;
 
     struct Loan {
     	address bor;        // Address Borrower
@@ -179,14 +179,15 @@ contract Loans is DSMath {
     }
 
     constructor (address funds_, address med_) public {
+        own = msg.sender;
     	funds = Funds(funds_);
     	med   = Medianizer(med_);
     }
 
     function setSales(address sales_) public {
-        require(!on);
+        require(msg.sender == own);
+        require(address(sales) == address(0));
         sales = Sales(sales_);
-        on = true;
     }
     
     function open(                  // Create new Loan

--- a/test/loans.js
+++ b/test/loans.js
@@ -255,4 +255,10 @@ contract("Loans", accounts => {
       assert.equal(sale, true)
     })
   })
+
+  describe('setSales', function() {
+    it('should not allow setSales to be called twice', async function() {
+      await shouldFail.reverting(this.loans.setSales(this.loans.address))
+    })
+  })
 })


### PR DESCRIPTION
### Description

This PR reduces vulnerabilities with `Loans` contract init race conditions.

`setSales` is used to set the `Loans` contract address after deployment. This PR this can only be called by the original deployer, and can only be called once.

Similar to: https://github.com/AtomicLoans/atomicloans-eth-contracts/pull/30

### Submission Checklist :pencil:

- [x] Add check to ensure `setSales` can only be called by deployer and only called once
- [x] Add tests to ensure `setSales` can't be called twice. 
