### PR TITLE
Fix Funds.push reentrancy attack vulnerability

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -128,8 +128,8 @@ contract Funds is DSMath {
 
     function push(bytes32 fund, uint256 amt) public { // Push funds to Loan Fund
         // require(msg.sender == lend(fund) || msg.sender == address(loans)); // NOTE: this require is not necessary. Anyone can fund someone elses loan fund
-        require(funds[fund].tok.transferFrom(msg.sender, address(this), amt));
         funds[fund].bal = add(funds[fund].bal, amt);
+        require(funds[fund].tok.transferFrom(msg.sender, address(this), amt));
     }
 
     function gen(bytes32[] memory sechs_) public { // Generate secret hashes for Loan Fund


### PR DESCRIPTION
### Description

Fix reentrancy attack Funds.pull vulnerability

`Funds.push` performs a transfer before the corresponding balance update. 

Fixed by moving the balance update to before the transfer.

Similar to: https://github.com/AtomicLoans/atomicloans-eth-contracts/pull/19

### Submission Checklist :pencil:

- [x] Move balance update before transfer
