### PR TITLE
Exclude MedianizerExample.sol and DSMath.sol from coveralls

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,6 @@
+module.exports = {
+  skipFiles: [
+    'DSMath.sol',
+    'MedianizerExample.sol'
+  ]
+};


### PR DESCRIPTION
### Description

This PR adds .solcover.js which excludes `MedianizerExample.sol` and `DSMath.sol` from coveralls

### Submission Checklist :pencil:

- [x] Exclude `MedianizerExample.sol` and `DSMath.sol` from coveralls
