### PR TITLE
Modify contract structure to be one token per contract

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -7,13 +7,14 @@ var Sales = artifacts.require('./Sales.sol');
 module.exports = function(deployer) {
   deployer.then(async () => {
     await deployer.deploy(ExampleCoin);
+    var token = await ExampleCoin.deployed();
     await deployer.deploy(Medianizer);
     var medianizer = await Medianizer.deployed();
-    await deployer.deploy(Funds);
+    await deployer.deploy(Funds, token.address);
     var funds = await Funds.deployed();
-    await deployer.deploy(Loans, funds.address, medianizer.address);
+    await deployer.deploy(Loans, funds.address, medianizer.address, token.address);
     var loans = await Loans.deployed();
-    await deployer.deploy(Sales, loans.address, medianizer.address);
+    await deployer.deploy(Sales, loans.address, medianizer.address, token.address);
     var sales = await Sales.deployed();
     await funds.setLoans(loans.address);
     await loans.setSales(sales.address);

--- a/test/funds.js
+++ b/test/funds.js
@@ -80,8 +80,7 @@ contract("Funds", accounts => {
       toWei(rateToSec('16.5'), 'gether'), // 16.50%
       toWei(rateToSec('3'), 'gether'), //  3.00%
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
-      agent,
-      this.token.address
+      agent
     ]
 
     this.fund = await this.funds.open.call(...fundParams)
@@ -189,8 +188,7 @@ contract("Funds", accounts => {
         toWei(rateToSec('16.5'), 'gether'), // 16.50%
         toWei(rateToSec('3'), 'gether'), //  3.00%
         toWei(rateToSec('0.75'), 'gether'), //  0.75%
-        agent,
-        this.token.address
+        agent
       ]
 
       this.fund = await this.funds.open.call(...fundParams)

--- a/test/loans.js
+++ b/test/loans.js
@@ -99,8 +99,7 @@ contract("Loans", accounts => {
       toWei(rateToSec('16.5'), 'gether'), // 16.50%
       toWei(rateToSec('3'), 'gether'), //  3.00%
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
-      agent,
-      this.token.address
+      agent
     ]
 
     this.fund = await this.funds.open.call(...fundParams)

--- a/test/sales.js
+++ b/test/sales.js
@@ -112,8 +112,7 @@ contract("Sales", accounts => {
       toWei(rateToSec('16.5'), 'gether'), // 16.50%
       toWei(rateToSec('3'), 'gether'), //  3.00%
       toWei(rateToSec('0.75'), 'gether'), //  0.75%
-      agent,
-      this.token.address
+      agent
     ]
 
     this.fund = await this.funds.open.call(...fundParams)


### PR DESCRIPTION
### Description

Currently, any `ERC20` token can be used as principal, but the system makes the assumption that only stablecoins are used. Supporting only a small set of whitelisted tokens would help signal to users that only stablecoins should be used, and it would also allow for auditing each `ERC20` token that's used. This would act as a "defense in depth" mitigation against issues around tokens that allow reentrancy or maliciously designed tokens.

This PR modifies the contract structure allow only one token to be used per `Funds`, `Loans` and `Sales` contract. This ensures proper due dilligence can be done on a stablecoin ERC20 token before deployment. 

### Submission Checklist :pencil:

- [x] Modify contract structure to allow only one token to be used per `Funds`, `Loans` and `Sales` contract
