### PR TITLE
Change public functions that don't have internal calls to external

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -101,7 +101,7 @@ contract Funds is DSMath {
         uint256  lpen_,  // Liquidation Penalty Rate
         uint256  lfee_,  // Optional Automation Fee Rate
         address  agent_  // Optional Address Automated Agent
-    ) public returns (bytes32 fund) {
+    ) external returns (bytes32 fund) {
         fundi = add(fundi, 1);
         fund = bytes32(fundi);
         funds[fund].lend  = msg.sender;
@@ -116,19 +116,19 @@ contract Funds is DSMath {
         funds[fund].agent = agent_;
     }
 
-    function push(bytes32 fund, uint256 amt) public { // Push funds to Loan Fund
+    function push(bytes32 fund, uint256 amt) external { // Push funds to Loan Fund
         // require(msg.sender == lend(fund) || msg.sender == address(loans)); // NOTE: this require is not necessary. Anyone can fund someone elses loan fund
         funds[fund].bal = add(funds[fund].bal, amt);
         require(token.transferFrom(msg.sender, address(this), amt));
     }
 
-    function gen(bytes32[] memory sechs_) public { // Generate secret hashes for Loan Fund
+    function gen(bytes32[] calldata sechs_) external { // Generate secret hashes for Loan Fund
         for (uint i = 0; i < sechs_.length; i++) {
             sechs[msg.sender].push(sechs_[i]);
         }
     }
 
-    function set(bytes memory pubk) public { // Set PubKey for Fund
+    function set(bytes calldata pubk) external { // Set PubKey for Fund
         pubks[msg.sender] = pubk;
     }
 
@@ -143,7 +143,7 @@ contract Funds is DSMath {
         uint256  lfee_,  // Optional Automation Fee in RAY
         uint256  rat_,   // Liquidation Ratio in RAY
         address  agent_  // Optional Automator Agent)
-    ) public {
+    ) external {
         require(msg.sender == lend(fund));
         funds[fund].mila  = mila_;
         funds[fund].mala  = mala_;
@@ -161,9 +161,9 @@ contract Funds is DSMath {
         uint256           amt_,   // Loan Amount
         uint256           col_,   // Collateral Amount in satoshis
         uint256           lodu_,  // Loan Duration in seconds
-        bytes32[4] memory sechs_, // Secret Hash A1 & A2
-        bytes      memory pubk_   // Pubkey
-    ) public returns (bytes32 loani) {
+        bytes32[4] calldata sechs_, // Secret Hash A1 & A2
+        bytes      calldata pubk_   // Pubkey
+    ) external returns (bytes32 loani) {
         require(msg.sender != lend(fund));
         require(amt_       <= bal(fund));
         require(amt_       >= mila(fund));
@@ -176,7 +176,7 @@ contract Funds is DSMath {
         loans.push(loani);
     }
 
-    function pull(bytes32 fund, uint256 amt) public { // Pull funds from Loan Fund
+    function pull(bytes32 fund, uint256 amt) external { // Pull funds from Loan Fund
         require(msg.sender == lend(fund));
         require(bal(fund)  >= amt);
         funds[fund].bal = sub(funds[fund].bal, amt);

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -188,18 +188,18 @@ contract Loans is DSMath {
         require(token.approve(address(funds), 2**256-1));
     }
 
-    function setSales(Sales sales_) public {
+    function setSales(Sales sales_) external {
         require(msg.sender == own);
         require(address(sales) == address(0));
         sales = sales_;
     }
     
-    function open(                  // Create new Loan
-        uint256            loex_,   // Loan Expiration
-        address[3] memory  usrs_,   // Borrower, Lender, Optional Automated Agent Addresses
-        uint256[6] memory  vals_,   // Principal, Interest, Liquidation Penalty, Optional Automation Fee, Collaateral Amount, Liquidation Ratio
-        bytes32            fundi_   // Optional Fund Index
-    ) public returns (bytes32 loan) {
+    function open(                   // Create new Loan
+        uint256             loex_,   // Loan Expiration
+        address[3] calldata usrs_,   // Borrower, Lender, Optional Automated Agent Addresses
+        uint256[6] calldata vals_,   // Principal, Interest, Liquidation Penalty, Optional Automation Fee, Collaateral Amount, Liquidation Ratio
+        bytes32             fundi_   // Optional Fund Index
+    ) external returns (bytes32 loan) {
         loani = add(loani, 1);
         loan = bytes32(loani);
         loans[loan].born   = now;
@@ -219,12 +219,12 @@ contract Loans is DSMath {
 
     function setSechs(             // Set Secret Hashes for Loan
     	bytes32           loan,    // Loan index
-    	bytes32[4] memory bsechs,  // Borrower Secret Hashes
-    	bytes32[4] memory lsechs,  // Lender Secret Hashes
-    	bytes32[4] memory asechs,  // Agent Secret Hashes
-		bytes      memory bpubk_,  // Borrower Pubkey
-        bytes      memory lpubk_   // Lender Pubkey
-	) public returns (bool) {
+	bytes32[4] calldata bsechs,  // Borrower Secret Hashes
+	bytes32[4] calldata lsechs,  // Lender Secret Hashes
+	bytes32[4] calldata asechs,  // Agent Secret Hashes
+		bytes      calldata bpubk_,  // Borrower Pubkey
+        bytes      calldata lpubk_   // Lender Pubkey
+	) external returns (bool) {
 		require(!sechs[loan].set);
 		require(msg.sender == loans[loan].bor || msg.sender == loans[loan].lend || msg.sender == address(funds));
 		sechs[loan].sechA1 = bsechs[0];
@@ -238,21 +238,21 @@ contract Loans is DSMath {
         sechs[loan].set    = true;
 	}
 
-	function push(bytes32 loan) public { // Fund Loan
+	function push(bytes32 loan) external { // Fund Loan
 		require(sechs[loan].set);
     	require(bools[loan].pushed == false);
     	require(token.transferFrom(msg.sender, address(this), prin(loan)));
     	bools[loan].pushed = true;
     }
 
-    function mark(bytes32 loan) public { // Mark Collateral as locked
+    function mark(bytes32 loan) external { // Mark Collateral as locked
     	require(bools[loan].pushed == true);
     	require(loans[loan].lend   == msg.sender);
     	require(now                <= apex(loan));
     	bools[loan].marked = true;
     }
 
-    function take(bytes32 loan, bytes32 secA1) public { // Withdraw
+    function take(bytes32 loan, bytes32 secA1) external { // Withdraw
     	require(!off(loan));
     	require(bools[loan].pushed == true);
     	require(bools[loan].marked == true);
@@ -261,7 +261,7 @@ contract Loans is DSMath {
     	bools[loan].taken = true;
     }
 
-    function pay(bytes32 loan, uint256 amt) public { // Payback Loan
+    function pay(bytes32 loan, uint256 amt) external { // Payback Loan
         // require(msg.sender                == loans[loan].bor); // NOTE: this is not necessary. Anyone can pay off the loan
     	require(!off(loan));
         require(!sale(loan));
@@ -276,7 +276,7 @@ contract Loans is DSMath {
     	}
     }
 
-    function unpay(bytes32 loan) public { // Refund payback
+    function unpay(bytes32 loan) external { // Refund payback
     	require(!off(loan));
         require(!sale(loan));
     	require(now              >  acex(loan));
@@ -286,7 +286,7 @@ contract Loans is DSMath {
     	require(token.transfer(loans[loan].bor, owed(loan)));
     }
 
-    function pull(bytes32 loan, bytes32 sec) public {
+    function pull(bytes32 loan, bytes32 sec) external {
         pull(loan, sec, true); // Default to true for returning funds to Fund
     }
 
@@ -310,7 +310,7 @@ contract Loans is DSMath {
         }
     }
 
-    function sell(bytes32 loan) public returns (bytes32 sale) { // Start Auction
+    function sell(bytes32 loan) external returns (bytes32 sale) { // Start Auction
     	require(!off(loan));
         require(bools[loan].taken  == true);
     	if (sales.next(loan) == 0) {

--- a/contracts/Sales.sol
+++ b/contracts/Sales.sol
@@ -155,8 +155,8 @@ contract Sales is DSMath { // Auctions
         address agent, // Optional Address automated agent
     	bytes32 sechA, // Secret Hash A
     	bytes32 sechB, // Secret Hash B
-    	bytes32 sechC  // Secret Hash C
-	) public returns(bytes32 sale) {
+    	bytes32 sechC // Secret Hash C
+	) external returns(bytes32 sale) {
     	require(msg.sender == own);
     	salei = add(salei, 1);
         sale = bytes32(salei);
@@ -177,7 +177,7 @@ contract Sales is DSMath { // Auctions
     	uint256 amt,   // Bid Amount
     	bytes32 sech,  // Secret Hash
     	bytes20 pbkh   // PubKeyHash
-	) public {
+	) external {
         require(msg.sender != bor(sale) && msg.sender != lend(sale));
 		require(sales[sale].set);
 	require(now < salex(sale));
@@ -199,11 +199,11 @@ contract Sales is DSMath { // Auctions
 
 	function sign(           // Provide Signature to move collateral to collateral swap
 		bytes32      sale,   // Auction Index
-		bytes memory rsig,   // Refundable Signature
-		bytes memory ssig,   // Seizable Signature
-		bytes memory rbsig,  // Refundable Back Signature
-		bytes memory sbsig   // Seizable Back Signataure
-	) public {
+		bytes calldata rsig,   // Refundable Signature
+		bytes calldata ssig,   // Seizable Signature
+		bytes calldata rbsig,  // Refundable Back Signature
+		bytes calldata sbsig   // Seizable Back Signataure
+	) external {
 		require(sales[sale].set);
 		require(now < setex(sale));
 		if (msg.sender == sales[sale].bor) {
@@ -226,7 +226,7 @@ contract Sales is DSMath { // Auctions
 		}
 	}
 
-	function sec(bytes32 sale, bytes32 sec_) public { // Provide Secret
+	function sec(bytes32 sale, bytes32 sec_) external { // Provide Secret
 		require(sales[sale].set);
 		if      (sha256(abi.encodePacked(sec_)) == sechs[sale].sechA) { sechs[sale].secA = sec_; }
         else if (sha256(abi.encodePacked(sec_)) == sechs[sale].sechB) { sechs[sale].secB = sec_; }
@@ -243,7 +243,7 @@ contract Sales is DSMath { // Auctions
 		return (secs >= 2);
 	}
 
-	function take(bytes32 sale) public { // Withdraw Bid (Accept Bid and disperse funds to rightful parties)
+	function take(bytes32 sale) external { // Withdraw Bid (Accept Bid and disperse funds to rightful parties)
         require(!taken(sale));
         require(!off(sale));
 		require(now > salex(sale));
@@ -273,7 +273,7 @@ contract Sales is DSMath { // Auctions
         if (available > 0) { require(token.transfer(sales[sale].bor, available)); }
 	}
 
-	function unpush(bytes32 sale) public { // Refund Bid
+	function unpush(bytes32 sale) external { // Refund Bid
         require(!taken(sale));
         require(!off(sale));
 		require(now > setex(sale));


### PR DESCRIPTION
### Description

Many of the functions throughout the system marked public could instead be external. Using external has two major advantages:

This PR converts `public` functions that don't have internal calls to `external`

### Submission Checklist :pencil:

- [x] Convert `public` functions that don't have internal calls to `external`
