### PR TITLE
4.3 Ensure that maxLoanDur and fundExpiry work simultaneously

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -526,12 +526,7 @@ contract Funds is DSMath, ALCompound {
         require(amount_    >= minLoanAmt(fund));
         require(amount_    <= maxLoanAmt(fund));
         require(loanDur_   >= minLoanDur(fund));
-
-        if (maxLoanDur(fund) > 0) {
-            require(loanDur_       <= maxLoanDur(fund));
-        } else {
-            require(now + loanDur_ <= fundExpiry(fund));
-        }
+        require(loanDur_   <= sub(fundExpiry(fund), now) && loanDur_ <= maxLoanDur(fund));
 
         loanIndex = createLoan(fund, borrower_, amount_, collateral_, loanDur_);
         loanSetSecretHashes(fund, loanIndex, secretHashes_, pubKeyA_, pubKeyB_);

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -454,6 +454,7 @@ contract Funds is DSMath, ALCompound {
         address  arbiter_
     ) public {
         require(msg.sender == lender(fund));
+        require(ensureNotZero(maxLoanDur_) != 2**256-1 || ensureNotZero(fundExpiry_) != 2**256-1); // Make sure someone can't request a loan for eternity
         funds[fund].maxLoanDur       = maxLoanDur_;
         funds[fund].fundExpiry       = fundExpiry_;
         funds[fund].arbiter          = arbiter_;

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -353,12 +353,13 @@ contract Funds is DSMath, ALCompound {
         uint256  amount_
     ) external returns (bytes32 fund) { 
         require(funds[fundOwner[msg.sender]].lender != msg.sender || msg.sender == deployer); // Only allow one loan fund per address
+        require(ensureNotZero(maxLoanDur_) != 2**256-1 || ensureNotZero(fundExpiry_) != 2**256-1); // Make sure someone can't request a loan for eternity
         if (!compoundSet) { require(compoundEnabled_ == false); }
         fundIndex = add(fundIndex, 1);
         fund = bytes32(fundIndex);
         funds[fund].lender           = msg.sender;
-        funds[fund].maxLoanDur       = maxLoanDur_;
-        funds[fund].fundExpiry       = fundExpiry_;
+        funds[fund].maxLoanDur       = ensureNotZero(maxLoanDur_);
+        funds[fund].fundExpiry       = ensureNotZero(fundExpiry_);
         funds[fund].arbiter          = arbiter_;
         bools[fund].custom           = false;
         bools[fund].compoundEnabled  = compoundEnabled_;
@@ -395,6 +396,7 @@ contract Funds is DSMath, ALCompound {
         uint256  amount_
     ) external returns (bytes32 fund) {
         require(funds[fundOwner[msg.sender]].lender != msg.sender || msg.sender == deployer); // Only allow one loan fund per address
+        require(ensureNotZero(maxLoanDur_) != 2**256-1 || ensureNotZero(fundExpiry_) != 2**256-1); // Make sure someone can't request a loan for eternity
         if (!compoundSet) { require(compoundEnabled_ == false); }
         fundIndex = add(fundIndex, 1);
         fund = bytes32(fundIndex);
@@ -402,8 +404,8 @@ contract Funds is DSMath, ALCompound {
         funds[fund].minLoanAmt       = minLoanAmt_;
         funds[fund].maxLoanAmt       = maxLoanAmt_;
         funds[fund].minLoanDur       = minLoanDur_;
-        funds[fund].maxLoanDur       = maxLoanDur_;
-        funds[fund].fundExpiry       = fundExpiry_;
+        funds[fund].maxLoanDur       = ensureNotZero(maxLoanDur_);
+        funds[fund].fundExpiry       = ensureNotZero(fundExpiry_);
         funds[fund].interest         = interest_;
         funds[fund].penalty          = penalty_;
         funds[fund].fee              = fee_;
@@ -665,6 +667,14 @@ contract Funds is DSMath, ALCompound {
         return sub(rmul(amount, rpow(rate, loanDur)), amount);
     }
 
+    /*
+     * @dev Ensure null values for fundExpiry and maxLoanDur are set to 2**256-1
+     * @param value The value to be sanity checked
+     */
+    function ensureNotZero(uint256 value) public pure returns (uint256) {
+        if (value == 0) { return 2**256-1; }
+        else            { return value; }
+    }
 
     /*
      * @dev Takes loan request parameters, creates loan, and returns loanIndex

--- a/test/compound.js
+++ b/test/compound.js
@@ -75,7 +75,7 @@ async function getContracts(stablecoin, accounts) {
 async function createFund(_this, arbiter, account, amount, compoundEnabled) {
   const fundParams = [
     toSecs({days: 366}),
-    0,
+    BN(2).pow(256).minus(1).toFixed(),
     arbiter, 
     compoundEnabled,
     0
@@ -167,7 +167,7 @@ stablecoins.forEach((stablecoin) => {
       it('should update cBalance based on compound exchange rate of cTokens', async function() {
         const fundParams = [
           toSecs({days: 366}),
-          0,
+          BN(2).pow(256).minus(1).toFixed(),
           arbiter, 
           true,
           0
@@ -277,7 +277,7 @@ stablecoins.forEach((stablecoin) => {
       it('should update cBalance based on compound exchange rate of cTokens', async function() {
         const fundParams = [
           toSecs({days: 366}),
-          0,
+          BN(2).pow(256).minus(1).toFixed(),
           arbiter, 
           true,
           0
@@ -370,7 +370,7 @@ stablecoins.forEach((stablecoin) => {
       it('should update cBalance based on compound exchange rate of cTokens', async function() {
         const fundParams = [
           toSecs({days: 366}),
-          0,
+          BN(2).pow(256).minus(1).toFixed(),
           arbiter, 
           true,
           0

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -297,7 +297,7 @@ stablecoins.forEach((stablecoin) => {
         toWei('100', unit),
         toSecs({days: 1}),
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         toWei('1.5', 'gether'), // 150% collateralization ratio
         toWei(rateToSec('16.5'), 'gether'), // 16.50%
         toWei(rateToSec('3'), 'gether'), //  3.00%

--- a/test/funds.js
+++ b/test/funds.js
@@ -183,6 +183,51 @@ stablecoins.forEach((stablecoin) => {
         assert.equal(maxLoanDur, BigNumber(2).pow(256).minus(1).toFixed())
         assert.equal(fundExpiry, newFundExpiry)
       })
+
+      it('should fail in updating non-custom loan fund with 2**256-1 maxLoanDur and fundExpiry', async function() {
+        const fundParams = [
+          toSecs({days: 366}),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          arbiter,
+          false,
+          0
+        ]
+
+        this.fund3 = await this.funds.create.call(...fundParams)
+        await this.funds.create(...fundParams)
+
+        const fundParams3 = [
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          arbiter
+        ]
+
+        await expectRevert(this.funds.update(this.fund3, ...fundParams3), 'VM Exception while processing transaction: revert')
+      })
+
+      it('should fail creating loan fund with 2**256-1 fundExpiry and maxLoanDur', async function() {
+        const fundParams = [
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          arbiter,
+          false,
+          0
+        ]
+
+        await expectRevert(this.funds.create(...fundParams), 'VM Exception while processing transaction: revert')
+      })
+
+      it('should fail creating loan fund with 0 fundExpiry and maxLoanDur', async function() {
+        const fundParams = [
+          0,
+          0,
+          arbiter,
+          false,
+          0
+        ]
+
+        await expectRevert(this.funds.create(...fundParams), 'VM Exception while processing transaction: revert')
+      })
     })
 
     describe('createCustom', function() {
@@ -205,6 +250,44 @@ stablecoins.forEach((stablecoin) => {
         await this.funds.createCustom(...fundParams, { from: lender3 })
 
         await expectRevert(this.funds.createCustom(...fundParams, { from: lender3 }), 'VM Exception while processing transaction: revert')
+      })
+
+      it('should fail creating custom loan fund with 2**256-1 fundExpiry and maxLoanDur', async function() {
+        const fundParams = [
+          toWei('1', unit),
+          toWei('100', unit),
+          toSecs({days: 1}),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          toWei('1.5', 'gether'), // 150% collateralization ratio
+          toWei(rateToSec('16.5'), 'gether'), // 16.50%
+          toWei(rateToSec('3'), 'gether'), //  3.00%
+          toWei(rateToSec('0.75'), 'gether'), //  0.75%
+          arbiter,
+          false,
+          0
+        ]
+
+        await expectRevert(this.funds.createCustom(...fundParams), 'VM Exception while processing transaction: revert')
+      })
+
+      it('should fail creating custom loan fund with 0 fundExpiry and maxLoanDur', async function() {
+        const fundParams = [
+          toWei('1', unit),
+          toWei('100', unit),
+          toSecs({days: 1}),
+          0,
+          0,
+          toWei('1.5', 'gether'), // 150% collateralization ratio
+          toWei(rateToSec('16.5'), 'gether'), // 16.50%
+          toWei(rateToSec('3'), 'gether'), //  3.00%
+          toWei(rateToSec('0.75'), 'gether'), //  0.75%
+          arbiter,
+          false,
+          0
+        ]
+
+        await expectRevert(this.funds.createCustom(...fundParams), 'VM Exception while processing transaction: revert')
       })
     })
 
@@ -373,6 +456,23 @@ stablecoins.forEach((stablecoin) => {
         assert.equal(penalty, toWei(rateToSec('2.75'), 'gether'))
         assert.equal(fee, toWei(rateToSec('0.5'), 'gether'))
         assert.equal(liquidationRatio, toWei('1.5', 'gether'))
+      })
+
+      it('should fail changing of fund details with 2**256-1 fundExpiry and maxLoanDur', async function() {
+        const fundParams = [
+          toWei('2', unit),
+          toWei('99', unit),
+          toSecs({days: 2}),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          BigNumber(2).pow(256).minus(1).toFixed(),
+          toWei(rateToSec('16'), 'gether'), // 16.0%
+          toWei(rateToSec('2.75'), 'gether'), //  3.00%
+          toWei(rateToSec('0.5'), 'gether'), //  0.75%
+          toWei('1.5', 'gether'), // 150% collateralization ratio
+          arbiter
+        ]
+
+        await expectRevert(this.funds.updateCustom(this.fund, ...fundParams), 'VM Exception while processing transaction: revert')
       })
     })
 

--- a/test/funds.js
+++ b/test/funds.js
@@ -126,7 +126,7 @@ stablecoins.forEach((stablecoin) => {
         toWei('100', unit),
         toSecs({days: 1}),
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         toWei('1.5', 'gether'), // 150% collateralization ratio
         toWei(rateToSec('16.5'), 'gether'), // 16.50%
         toWei(rateToSec('3'), 'gether'), //  3.00%
@@ -144,7 +144,7 @@ stablecoins.forEach((stablecoin) => {
       it('should fail if user tries to create two loan funds', async function() {
         const fundParams = [
           toSecs({days: 366}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           arbiter,
           false,
           0
@@ -158,7 +158,7 @@ stablecoins.forEach((stablecoin) => {
       it('should succeed in updating non-custom loan fund', async function() {
         const fundParams = [
           toSecs({days: 366}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           arbiter,
           false,
           0
@@ -170,7 +170,7 @@ stablecoins.forEach((stablecoin) => {
         const newFundExpiry = Math.floor(Date.now() / 1000) + toSecs({days: 366})
 
         const fundParams2 = [
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           newFundExpiry,
           arbiter
         ]
@@ -180,7 +180,7 @@ stablecoins.forEach((stablecoin) => {
         const maxLoanDur = await this.funds.maxLoanDur.call(this.fund2)
         const fundExpiry = await this.funds.fundExpiry.call(this.fund2)
 
-        assert.equal(maxLoanDur, 0)
+        assert.equal(maxLoanDur, BigNumber(2).pow(256).minus(1).toFixed())
         assert.equal(fundExpiry, newFundExpiry)
       })
     })
@@ -192,7 +192,7 @@ stablecoins.forEach((stablecoin) => {
           toWei('100', unit),
           toSecs({days: 1}),
           toSecs({days: 366}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           toWei('1.5', 'gether'), // 150% collateralization ratio
           toWei(rateToSec('16.5'), 'gether'), // 16.50%
           toWei(rateToSec('3'), 'gether'), //  3.00%
@@ -307,7 +307,7 @@ stablecoins.forEach((stablecoin) => {
           toWei('100', unit),
           toSecs({days: 1}),
           toSecs({days: 366}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           toWei('1.5', 'gether'), // 150% collateralization ratio
           toWei(rateToSec('16.5'), 'gether'), // 16.50%
           toWei(rateToSec('3'), 'gether'), //  3.00%
@@ -346,7 +346,7 @@ stablecoins.forEach((stablecoin) => {
           toWei('99', unit),
           toSecs({days: 2}),
           toSecs({days: 364}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           toWei(rateToSec('16'), 'gether'), // 16.0%
           toWei(rateToSec('2.75'), 'gether'), //  3.00%
           toWei(rateToSec('0.5'), 'gether'), //  0.75%
@@ -428,7 +428,7 @@ stablecoins.forEach((stablecoin) => {
           toWei('1', unit),
           toWei('100', unit),
           toSecs({days: 1}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           parseInt(fromWei(currentTime, 'wei')) + toSecs({days: 30}),
           toWei('1.5', 'gether'), // 150% collateralization ratio
           toWei(rateToSec('16.5'), 'gether'), // 16.50%
@@ -469,7 +469,7 @@ stablecoins.forEach((stablecoin) => {
           toWei('1', unit),
           toWei('100', unit),
           toSecs({days: 1}),
-          0,
+          BigNumber(2).pow(256).minus(1).toFixed(),
           parseInt(fromWei(currentTime, 'wei')) + toSecs({days: 30}),
           toWei('1.5', 'gether'), // 150% collateralization ratio
           toWei(rateToSec('16.5'), 'gether'), // 16.50%

--- a/test/interestDecrease.js
+++ b/test/interestDecrease.js
@@ -218,7 +218,7 @@ stablecoins.forEach((stablecoin) => {
 
       const fundParams = [
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         arbiter,
         false,
         0

--- a/test/interestIncrease.js
+++ b/test/interestIncrease.js
@@ -217,7 +217,7 @@ stablecoins.forEach((stablecoin) => {
 
       const fundParams = [
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         arbiter,
         false,
         0

--- a/test/loans.js
+++ b/test/loans.js
@@ -134,7 +134,7 @@ stablecoins.forEach((stablecoin) => {
         toWei('100', unit),
         toSecs({days: 1}),
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         toWei('1.5', 'gether'), // 150% collateralization ratio
         toWei(rateToSec('16.5'), 'gether'), // 16.50%
         toWei(rateToSec('3'), 'gether'), //  3.00%

--- a/test/sales.js
+++ b/test/sales.js
@@ -225,7 +225,7 @@ stablecoins.forEach((stablecoin) => {
         toWei('100', unit),
         toSecs({days: 1}),
         toSecs({days: 366}),
-        0,
+        BigNumber(2).pow(256).minus(1).toFixed(),
         toWei('1.5', 'gether'), // 150% collateralization ratio
         toWei(rateToSec('16.5'), 'gether'), // 16.50%
         toWei(rateToSec('3'), 'gether'), //  3.00%


### PR DESCRIPTION
### Description

This PR ensures that `maxLoanDur` and `fundExpiry` can work simultaneously. 

Issue can be seen in more detail here: https://diligence.consensys.net/audits/private/o3sxioyi-atomic-loans/index.html#funds-maxfunddur-has-no-effect-if-maxloandur-is-set

### Submission Checklist :pencil:

- [x] Ensures that `maxLoanDur` and `fundExpiry` can work simultaneously in `Funds.sol`
