### PR TITLE
Bump CAL and CAL-Loans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,13 @@ before_install:
 apt_packages:
   - bitcoind
 before_script:
+  - npm install
   - npm install -g ganache-cli
   - mkdir -p /home/travis/.bitcoin && cp bitcoin.conf /home/travis/.bitcoin/bitcoin.conf
   - bitcoind -reindex -txindex -regtest -daemon -rpcport=18443 -rpcuser=bitcoin -rpcpassword=local321 -deprecatedrpc=signrawtransaction
 script:
   - CI=false ganache-cli -k byzantium &
-  - CI=false yarn test
+  - CI=false npm run test
 after_script:
   - npx codechecks
   - npm run coverage && cat coverage/lcov.info | coveralls

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -112,15 +112,15 @@ module.exports = function(deployer, network, accounts) {
 
     await deployer.deploy(ALCompound, comptroller.address)
 
-    console.log('daiAddress', dai.address)
-    console.log('usdcAddress', usdc.address)
+    console.log(`DAI_ADDRESS=${dai.address}`)
+    console.log(`USDC_ADDRESS=${usdc.address}`)
 
-    console.log('daiFunds Address', funds.address)
-    console.log('daiLoans Address', loans.address)
-    console.log('daiSales Address', sales.address)
+    console.log(`DAI_LOAN_FUNDS_ADDRESS=${funds.address}`)
+    console.log(`DAI_LOAN_LOANS_ADDRESS=${loans.address}`)
+    console.log(`DAI_LOAN_SALES_ADDRESS=${sales.address}`)
 
-    console.log('usdcFunds Address', usdcFunds.address)
-    console.log('usdcLoans Address', usdcLoans.address)
-    console.log('usdcSales Address', usdcSales.address)
+    console.log(`USDC_LOAN_FUNDS_ADDRESS=${usdcFunds.address}`)
+    console.log(`USDC_LOAN_LOANS_ADDRESS=${usdcLoans.address}`)
+    console.log(`USDC_LOAN_SALES_ADDRESS=${usdcSales.address}`)
   })
 };

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "atomicloans-solidity",
   "version": "0.1.0",
   "dependencies": {
-    "@liquality/crypto": "^0.3.3",
-    "@liquality/ethereum-utils": "^0.3.3",
+    "@liquality/crypto": "^0.3.6",
+    "@liquality/ethereum-utils": "^0.3.6",
     "@mblackmblack/to-seconds": "^0.1.0",
-    "axios": "^0.19.0", 
+    "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "decimal.js": "^10.2.0",
     "lodash": "^4.17.13",
@@ -30,8 +30,8 @@
     "coverage": "npx solidity-coverage"
   },
   "devDependencies": {
-    "@atomicloans/loan-bundle": "^0.2.53",
-    "@atomicloans/provider": "^0.2.48",
+    "@atomicloans/loan-bundle": "^0.3.1",
+    "@atomicloans/provider": "^0.3.1",
     "@codechecks/client": "^0.1.5",
     "@liquality/bundle": "^0.3.2",
     "bitcoinjs-lib": "^5.1.3",


### PR DESCRIPTION
### Description

This PR Bumps the `ChainAbstractionLayer` to `0.3.6` and `ChainAbstractionLayer-Loans` packages to `0.3.1`

### Submission Checklist :pencil:

- [x] Bump CAL to `0.3.6`
- [x] Bump CAL-loans to `0.3.1`
