### PR TITLE
Add borrower and lender loans getter

### DIFF
--- a/test/loans.js
+++ b/test/loans.js
@@ -213,6 +213,22 @@ stablecoins.forEach((stablecoin) => {
       })
     })
 
+    describe('getters', function() {
+      it('should add borrower to borrowerLoans list after requesting loan', async function() {
+        const borrowerLoanCount = await this.loans.borrowerLoanCount.call(borrower)
+        const borrowerLoan = await this.loans.borrowerLoans.call(borrower, borrowerLoanCount.toNumber() - 1)
+
+        assert.equal(borrowerLoan, this.loan)
+      })
+
+      it('should add lender to lenderLoans list after requesting loan', async function() {
+        const lenderLoanCount = await this.loans.lenderLoanCount.call(lender)
+        const lenderLoan = await this.loans.lenderLoans.call(lender, lenderLoanCount.toNumber() - 1)
+
+        assert.equal(lenderLoan, this.loan)
+      })
+    })
+
     describe('liquidate', function() {
       it('should be safe if above liquidation ratio', async function() {
         await this.loans.approve(this.loan)


### PR DESCRIPTION
### Description

This PR adds a two getters `lenderLoans` and `borrowerLoans` for getting all loans associated with a specific lender or borrower. 

### Submission Checklist :pencil:

- [x] Add `lenderLoans` to `Loans.sol`
- [x] Add `borrowerLoans` to `Loans.sol`
- [x] Add `lenderLoansCount` to `Loans.sol`
- [x] Add `borrowerLoansCount` to `Loans.sol`
- [x] Add tests for both `lenderLoans` and `borrowerLoans`
