### PR TITLE
Add request timestamp to Funds.request for easier secret generation

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -62,6 +62,7 @@ contract Loans is DSMath {
         uint256 fee;
         uint256 collateral;
         uint256 liquidationRatio;
+        uint256 requestTimestamp;
     }
 
     /**
@@ -285,7 +286,7 @@ contract Loans is DSMath {
     function create(
         uint256             loanExpiration_,
         address[3] calldata usrs_,
-        uint256[6] calldata vals_,
+        uint256[7] calldata vals_,
         bytes32             fundIndex_
     ) external returns (bytes32 loan) {
         if (fundIndex_ != bytes32(0)) { require(funds.lender(fundIndex_) == usrs_[1]); }
@@ -302,6 +303,7 @@ contract Loans is DSMath {
         loans[loan].fee              = vals_[3];
         loans[loan].collateral       = vals_[4];
         loans[loan].liquidationRatio = vals_[5];
+        loans[loan].requestTimestamp = vals_[6];
         fundIndex[loan]              = fundIndex_;
         secretHashes[loan].set       = false;
         borrowerLoans[usrs_[0]].push(bytes32(loanIndex));

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,8 @@
 const { toWei, fromWei, padLeft, numberToHex } = web3.utils;
 
+const toSecs = require('@mblackmblack/to-seconds');
+const BN = require('bignumber.js')
+
 var ExampleDaiCoin = artifacts.require("./ExampleDaiCoin.sol");
 var ExampleUsdcCoin = artifacts.require("./ExampleUsdcCoin.sol");
 var Medianizer = artifacts.require('./MedianizerExample.sol');
@@ -114,6 +117,9 @@ module.exports = function(deployer, network, accounts) {
 
     console.log(`DAI_ADDRESS=${dai.address}`)
     console.log(`USDC_ADDRESS=${usdc.address}`)
+
+    console.log(`CDAI_ADDRESS=${cdai.address}`)
+    console.log(`CUSDC_ADDRESS=${cusdc.address}`)
 
     console.log(`DAI_LOAN_FUNDS_ADDRESS=${funds.address}`)
     console.log(`DAI_LOAN_LOANS_ADDRESS=${loans.address}`)

--- a/test/compound.js
+++ b/test/compound.js
@@ -421,6 +421,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 2}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -479,6 +480,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 2}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -326,6 +326,7 @@ stablecoins.forEach((stablecoin) => {
         toWei(loanReq.toString(), unit),
         col,
         toSecs({days: 2}),
+        Math.floor(Date.now() / 1000),
         [ ...borSechs, ...lendSechs ],
         ensure0x(borrowerBTC.pubKey.toString('hex')),
         ensure0x(lenderBTC.pubKey.toString('hex'))

--- a/test/funds.js
+++ b/test/funds.js
@@ -353,6 +353,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 2}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -553,6 +554,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 2}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -594,6 +596,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 31}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)

--- a/test/interestDecrease.js
+++ b/test/interestDecrease.js
@@ -267,6 +267,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq3.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -450,6 +451,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq4.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs7, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)

--- a/test/interestIncrease.js
+++ b/test/interestIncrease.js
@@ -273,6 +273,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -311,6 +312,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs2, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -344,6 +346,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs3, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -377,6 +380,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs4, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -411,6 +415,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs5, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -444,6 +449,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs6, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -501,6 +507,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq2.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs7, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -536,6 +543,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq2.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs8, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -571,6 +579,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq2.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs9, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -606,6 +615,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq2.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs10, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)
@@ -640,6 +650,7 @@ stablecoins.forEach((stablecoin) => {
           toWei(loanReq2.toString(), unit),
           col,
           toSecs({days: 10}),
+          Math.floor(Date.now() / 1000),
           [ ...borSechs11, ...lendSechs ],
           ensure0x(borpubk),
           ensure0x(lendpubk)

--- a/test/loans.js
+++ b/test/loans.js
@@ -164,6 +164,7 @@ stablecoins.forEach((stablecoin) => {
         toWei(loanReq.toString(), unit),
         col,
         toSecs({days: 2}),
+        Math.floor(Date.now() / 1000),
         [ ...borSechs, ...lendSechs ],
         ensure0x(borpubk),
         ensure0x(lendpubk)

--- a/test/sales.js
+++ b/test/sales.js
@@ -255,6 +255,7 @@ stablecoins.forEach((stablecoin) => {
         toWei(loanReq.toString(), unit),
         col,
         toSecs({days: 2}),
+        Math.floor(Date.now() / 1000),
         [ ...borSechs, ...lendSechs ],
         ensure0x(borpubk),
         ensure0x(lendpubk)


### PR DESCRIPTION
### Description

This PR introduces a `requestTimestamp` parameter that is passed into `Funds.request` function. This is used to generation secret hashes, and provides and easy way for borrowers and lenders to generate the necessary `secretMsg` that will be signed and used to generate secrets for the debt agreement, and also an easy way for them to find that `secretMsg` again, allowing them to regenerate their secrets for the debt agreement. 

`secretMsg` takes the following form: 

```
const secretData = [
        principalValue, // Principal Value (Wei)
        principal, // Principal (i.e. DAI)
        collateralValue, // Collateral Value (Sats)
        collateral, // Collateral (i.e. BTC)
        borrowerPrincipalAddress, // Borrower Principal Address
        lenderPrincipalAddress, // Lender Principal Address
        borrowerCollateralPublicKey, // Borrower Collateral PubKey
        lenderCollateralPublicKey, // Lender Collateral PubKey
        requestCreatedAt // Fund Id as number (`requestTimestamp` that was just added)
]

const secretMsg = secretData.join('')
```

This can then be passed into `generateSecrets` in https://github.com/AtomicLoans/chainabstractionlayer-loans/blob/master/packages/loan-client/lib/Secrets.js#L14

### Submission Checklist :pencil:

- [x] Add `requestTimestamp` to `Funds.request`
