### PR TITLE
Fix withdraw vulnerability state checking

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -379,6 +379,7 @@ contract Loans is DSMath {
     	require(!off(loan));
     	require(bools[loan].funded == true);
     	require(bools[loan].approved == true);
+        require(bools[loan].withdrawn == false);
     	require(sha256(abi.encodePacked(secretA1)) == secretHashes[loan].secretHashA1);
     	require(token.transfer(loans[loan].borrower, principal(loan)));
     	bools[loan].withdrawn = true;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -152,7 +152,8 @@ module.exports = function(deployer, network, accounts) {
     console.log(`  "DAI_SALES": "${sales.address}",`)
     console.log(`  "USDC_FUNDS": "${usdcFunds.address}",`)
     console.log(`  "USDC_LOANS": "${usdcLoans.address}",`)
-    console.log(`  "USDC_SALES": "${usdcSales.address}"`)
+    console.log(`  "USDC_SALES": "${usdcSales.address}",`)
+    console.log(`  "MEDIANIZER": "${medianizer.address}"`)
     console.log('}')
   })
 };

--- a/test/loans.js
+++ b/test/loans.js
@@ -316,6 +316,16 @@ stablecoins.forEach((stablecoin) => {
       })
     })
 
+    describe('withdraw', function() {
+      it('should fail trying to withdraw twice', async function() {
+        await this.loans.approve(this.loan)
+
+        await this.loans.withdraw(this.loan, borSecs[0], { from: borrower })
+
+        await expectRevert(this.loans.withdraw(this.loan, borSecs[0], { from: borrower }), 'VM Exception while processing transaction: revert')
+      })
+    })
+
     describe('setSales', function() {
       it('should not allow setSales to be called twice', async function() {
         await expectRevert(this.loans.setSales(this.loans.address), 'VM Exception while processing transaction: revert')


### PR DESCRIPTION
### Description

Previously there was no `require(bools[loan].withdrawn == false);` in `Loans.withdraw`, meaning anyone could drain the entire Loans contract by requesting a loan, and withdrawing multiple times. This PR solves that vulnerability by adding this line to the `withdraw` function. 

### Submission Checklist :pencil:

- [x] Add `require` for `withdrawn` to be false in `Loans.withdraw`
