### PR TITLE
Fix minSeizableCollateral value calculation

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -312,7 +312,7 @@ contract Loans is DSMath {
     function minSeizableCollateralValue(bytes32 loan) public view returns (uint256) {
         (bytes32 val, bool set) = med.peek();
         uint256 price = uint(val);
-        return div(wdiv(dmul(add(principal(loan), interest(loan))), price), (10 ** 12));
+        return div(wdiv(dmul(add(principal(loan), interest(loan))), price), (10 ** 10));
     }
 
     function collateralValue(bytes32 loan) public view returns (uint256) { // Current Collateral Value

--- a/test/interestDecrease.js
+++ b/test/interestDecrease.js
@@ -274,7 +274,7 @@ stablecoins.forEach((stablecoin) => {
 
       btcPrice = '9340.23'
 
-      col = Math.round(((loanReq * loanRat) / btcPrice) * BTC_TO_SAT)
+      col = Math.round(((loanReq4 * loanRat) / btcPrice) * BTC_TO_SAT)
 
       const { funds, loans, sales, token, med } = await getContracts(name)
 


### PR DESCRIPTION
### Description

This PR fixes the calculation for `minSeizableCollateral`. `(principal + interest) / btcPrice` is in `10e18` and needs to be converted to `10e8`. Currently this is being converted to `10e10` which is incorrect. This PR fixes that. 

### Submission Checklist :pencil:

- [x] Change conversion of `principal + interest` to `sats` from `10e10` to `10e8`
