### PR TITLE
QSP-8: Integer Overflow / Underflow

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -674,7 +674,7 @@ contract Funds is DSMath, ALCompound {
     function calcGlobalInterest() public {
         marketLiquidity = add(tokenMarketLiquidity, wmul(cTokenMarketLiquidity, cTokenExchangeRate()));
 
-        if (now > (lastGlobalInterestUpdated + interestUpdateDelay)) {
+        if (now > (add(lastGlobalInterestUpdated, interestUpdateDelay))) {
             uint256 utilizationRatio;
             if (totalBorrow != 0) { utilizationRatio = rdiv(totalBorrow, add(marketLiquidity, totalBorrow)); }
 


### PR DESCRIPTION
### Description

There is a potential integer overflow on L677 in the expression now > (lastGlobalInterestUpdated + interestUpdateDelay, because the deployer is allowed to set the interestUpdateDelay to any value. This would have the effect of updating the global interest value in a scenario where it should not be updated.

### Submission Checklist :pencil:

- [x] Use safe add method
