### PR TITLE
QSP-10 gas usage for loop concerns

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -42,7 +42,6 @@ contract Loans is DSMath {
     mapping (address => bytes32[])           public lenderLoans;
 
     mapping (uint256 => RequestDetails)      public requestsDetails;
-    mapping (uint256 => bool)                public requestsValid;
 
     mapping (uint256 => uint256)             public finalRequestToInitialRequest;
 
@@ -53,6 +52,7 @@ contract Loans is DSMath {
 
     mapping (address => mapping(uint256 => bool))              public addressToTimestamp;
     mapping (bytes32 => mapping(uint8 => uint256))             public txidToOutputIndexToCollateralDepositIndex;
+    mapping (bytes32 => mapping(uint8 => bool))                public txidToOutputToRequestValid;
 
     ERC20 public token; // ERC20 Debt Stablecoin
     uint256 public decimals;
@@ -480,7 +480,7 @@ contract Loans is DSMath {
         require(BytesLib.toBytes32(BTCUtils.extractHash(outputAtIndex)) == requestsDetails[_requestID].p2wshAddress); // ensure p2wsh is generated properly
 
         if (requestsDetails[_requestID].finalized) { // 6 confirmations
-            if (requestsValid[finalRequestToInitialRequest[_requestID]]) { // Check that request is valid
+            if (txidToOutputToRequestValid[_txid][_outputIndex]) { // Check that request is valid
                 if (requestsDetails[_requestID].seizable) {
                     collaterals[loan].seizableCollateral = add(collaterals[loan].seizableCollateral, amount);
 
@@ -498,24 +498,30 @@ contract Loans is DSMath {
 
                 collateralDeposits[loan][txidToOutputIndexToCollateralDepositIndex[_txid][_outputIndex]].finalized = true;
 
-                for (uint i = collateralDepositFinalizedIndex[loan]; i <= collateralDepositIndex[loan]; i++) { // check if collateralDepositFinalizedIndex should be increased
-                    if (collateralDeposits[loan][i].finalized == true) {
-                        collateralDepositFinalizedIndex[loan] = add(collateralDepositFinalizedIndex[loan], 1);
+                _updateCollateralDepositFinalizedIndex(loan);
+            } else { // In the case that 6 conf comes before 1 conf
+                if (amount >= div(collateral(loan), 100)) { // Ensure amount is greater than 1% of collateral value
+                    txidToOutputToRequestValid[_txid][_outputIndex] = true;
+                    _setCollateralDeposit(loan, collateralDepositIndex[loan], amount, requestsDetails[_requestID].seizable);
+                    collateralDeposits[loan][collateralDepositIndex[loan]].finalized = true;
+                    txidToOutputIndexToCollateralDepositIndex[_txid][_outputIndex] = collateralDepositIndex[loan];
+                    collateralDepositIndex[loan] = add(collateralDepositIndex[loan], 1);
+
+                    if (requestsDetails[_requestID].seizable) {
+                        collaterals[loan].seizableCollateral = add(collaterals[loan].seizableCollateral, amount);
                     } else {
-                        break;
+                        collaterals[loan].refundableCollateral = add(collaterals[loan].refundableCollateral, amount);
                     }
+
+                    _updateExistingRefundableCollateral(loan);
+                    _updateCollateralDepositFinalizedIndex(loan);
                 }
             }
         } else { // 1 confirmation
-            if (amount >= div(collateral(loan), 100)) { // Ensure amount is greater than 1% of collateral value
-                requestsValid[_requestID] = true;
-
-                collateralDeposits[loan][collateralDepositIndex[loan]].amount = amount;
-                collateralDeposits[loan][collateralDepositIndex[loan]].seizable = requestsDetails[_requestID].seizable;
-                collateralDeposits[loan][collateralDepositIndex[loan]].expiry = now + ADD_COLLATERAL_EXPIRY;
-
+            if (amount >= div(collateral(loan), 100) && !txidToOutputToRequestValid[_txid][_outputIndex]) { // Ensure amount is greater than 1% of collateral value
+                txidToOutputToRequestValid[_txid][_outputIndex] = true;
+                _setCollateralDeposit(loan, collateralDepositIndex[loan], amount, requestsDetails[_requestID].seizable);
                 txidToOutputIndexToCollateralDepositIndex[_txid][_outputIndex] = collateralDepositIndex[loan];
-
                 collateralDepositIndex[loan] = add(collateralDepositIndex[loan], 1);
 
                 if (requestsDetails[_requestID].seizable) {
@@ -524,11 +530,31 @@ contract Loans is DSMath {
                     temporaryCollaterals[loan].refundableCollateral = add(temporaryCollaterals[loan].refundableCollateral, amount);
                 }
 
-                // check existing refundable collaterals
-                if (add(collaterals[loan].seizableCollateral, temporaryCollaterals[loan].seizableCollateral) >= minSeizableCollateralValue(loan) && collaterals[loan].unaccountedRefundableCollateral != 0) {
-                    collaterals[loan].refundableCollateral = add(collaterals[loan].refundableCollateral, collaterals[loan].unaccountedRefundableCollateral);
-                    collaterals[loan].unaccountedRefundableCollateral = 0;
-                }
+                _updateExistingRefundableCollateral(loan);
+            }
+        }
+    }
+
+    function _setCollateralDeposit (bytes32 loan, uint256 collateralDepositIndex_, uint256 amount_, bool seizable_) private {
+        collateralDeposits[loan][collateralDepositIndex_].amount = amount_;
+        collateralDeposits[loan][collateralDepositIndex_].seizable = seizable_;
+        collateralDeposits[loan][collateralDepositIndex_].expiry = now + ADD_COLLATERAL_EXPIRY;
+    }
+
+    function _updateExistingRefundableCollateral (bytes32 loan) private {
+        // check existing refundable collaterals
+        if (add(collaterals[loan].seizableCollateral, temporaryCollaterals[loan].seizableCollateral) >= minSeizableCollateralValue(loan) && collaterals[loan].unaccountedRefundableCollateral != 0) {
+            collaterals[loan].refundableCollateral = add(collaterals[loan].refundableCollateral, collaterals[loan].unaccountedRefundableCollateral);
+            collaterals[loan].unaccountedRefundableCollateral = 0;
+        }
+    }
+
+    function _updateCollateralDepositFinalizedIndex (bytes32 loan) private {
+        for (uint i = collateralDepositFinalizedIndex[loan]; i <= collateralDepositIndex[loan]; i++) { // check if collateralDepositFinalizedIndex should be increased
+            if (collateralDeposits[loan][i].finalized == true) {
+                collateralDepositFinalizedIndex[loan] = add(collateralDepositFinalizedIndex[loan], 1);
+            } else {
+                break;
             }
         }
     }

--- a/test/spv.js
+++ b/test/spv.js
@@ -1041,10 +1041,301 @@ stablecoins.forEach((stablecoin) => {
         const { acceptSecret } = await this.loans.secretHashes.call(this.loan)
         await unlockCollateral(acceptSecret, borrowerBTC, lockTxHash, colParams, col)
       })
+
+      it('should account for delayed 6 conf proofs in collateral value', async function() {
+        const { colParams, owedForLoan, lockTxHash } = await lockApproveWithdraw(this.loans, this.loan, btcPrice, unit, col, borrower, borSecs[0])
+
+        const { refundRequestIDOneConf, refundRequestIDSixConf, seizeRequestIDOneConf, seizeRequestIDSixConf } = await getLoanSpvRequests(this.loans, this.onDemandSpv, this.loan) // Get loan spv requests associated with loan
+
+        const collateralValueBeforeAddingCollateral = await this.loans.collateral.call(this.loan)
+
+        await this.med.poke(numToBytes32(toWei((parseFloat(btcPrice) * 1.2).toString(), 'ether'))) // Ensure minSeizableCollateral not satisfied
+
+        const lockMoreCollateralParams = [colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+        const lockMoreCollateralAddresses = await bitcoin.client.loan.collateral.getLockAddresses(...lockMoreCollateralParams)
+        const { refundableAddress, seizableAddress } = lockMoreCollateralAddresses
+        const { refundableValue, seizableValue } = colParams.values
+
+        // Lock More Collateral 1
+        const lockMoreCollateral_1_TxHash = await bitcoin.client.loan.collateral.lock(colParams.values, ...lockMoreCollateralParams)
+        const lockMoreCollateral_1_TxHashForProof = ensure0x(Buffer.from(lockMoreCollateral_1_TxHash, 'hex').reverse().toString('hex'))
+
+        const lockMoreCollateral_1_TxRaw = await bitcoin.client.getMethod('getRawTransactionByHash')(lockMoreCollateral_1_TxHash)
+        const lockMoreCollateral_1_Tx = await bitcoin.client.getMethod('decodeRawTransaction')(lockMoreCollateral_1_TxRaw)
+
+        const lockMoreCollateral_1_RefundableVout = lockMoreCollateral_1_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === refundableAddress)
+        const lockMoreCollateral_1_SeizableVout = lockMoreCollateral_1_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === seizableAddress)
+
+        const lockMoreCollateral_1_BitcoinJsTx = bitcoinjs.Transaction.fromHex(lockMoreCollateral_1_TxRaw)
+        const lockMoreCollateral_1_Vin = ensure0x(lockMoreCollateral_1_BitcoinJsTx.getVin())
+        const lockMoreCollateral_1_Vout = ensure0x(lockMoreCollateral_1_BitcoinJsTx.getVout())
+
+        // Lock More Collateral 2
+        const lockMoreCollateral_2_TxHash = await bitcoin.client.loan.collateral.lock(colParams.values, ...lockMoreCollateralParams)
+        const lockMoreCollateral_2_TxHashForProof = ensure0x(Buffer.from(lockMoreCollateral_2_TxHash, 'hex').reverse().toString('hex'))
+
+        const lockMoreCollateral_2_TxRaw = await bitcoin.client.getMethod('getRawTransactionByHash')(lockMoreCollateral_2_TxHash)
+        const lockMoreCollateral_2_Tx = await bitcoin.client.getMethod('decodeRawTransaction')(lockMoreCollateral_2_TxRaw)
+
+        const lockMoreCollateral_2_RefundableVout = lockMoreCollateral_2_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === refundableAddress)
+        const lockMoreCollateral_2_SeizableVout = lockMoreCollateral_2_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === seizableAddress)
+
+        const lockMoreCollateral_2_BitcoinJsTx = bitcoinjs.Transaction.fromHex(lockMoreCollateral_2_TxRaw)
+        const lockMoreCollateral_2_Vin = ensure0x(lockMoreCollateral_2_BitcoinJsTx.getVin())
+        const lockMoreCollateral_2_Vout = ensure0x(lockMoreCollateral_2_BitcoinJsTx.getVout())
+
+        // Lock More Collateral 3
+        const lockMoreCollateral_3_TxHash = await bitcoin.client.loan.collateral.lock(colParams.values, ...lockMoreCollateralParams)
+        const lockMoreCollateral_3_TxHashForProof = ensure0x(Buffer.from(lockMoreCollateral_3_TxHash, 'hex').reverse().toString('hex'))
+
+        const lockMoreCollateral_3_TxRaw = await bitcoin.client.getMethod('getRawTransactionByHash')(lockMoreCollateral_3_TxHash)
+        const lockMoreCollateral_3_Tx = await bitcoin.client.getMethod('decodeRawTransaction')(lockMoreCollateral_3_TxRaw)
+
+        const lockMoreCollateral_3_RefundableVout = lockMoreCollateral_3_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === refundableAddress)
+        const lockMoreCollateral_3_SeizableVout = lockMoreCollateral_3_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === seizableAddress)
+
+        const lockMoreCollateral_3_BitcoinJsTx = bitcoinjs.Transaction.fromHex(lockMoreCollateral_3_TxRaw)
+        const lockMoreCollateral_3_Vin = ensure0x(lockMoreCollateral_3_BitcoinJsTx.getVin())
+        const lockMoreCollateral_3_Vout = ensure0x(lockMoreCollateral_3_BitcoinJsTx.getVout())
+
+        // Lock More Collateral 3
+        const lockMoreCollateral_4_TxHash = await bitcoin.client.loan.collateral.lock(colParams.values, ...lockMoreCollateralParams)
+        const lockMoreCollateral_4_TxHashForProof = ensure0x(Buffer.from(lockMoreCollateral_4_TxHash, 'hex').reverse().toString('hex'))
+
+        const lockMoreCollateral_4_TxRaw = await bitcoin.client.getMethod('getRawTransactionByHash')(lockMoreCollateral_4_TxHash)
+        const lockMoreCollateral_4_Tx = await bitcoin.client.getMethod('decodeRawTransaction')(lockMoreCollateral_4_TxRaw)
+
+        const lockMoreCollateral_4_RefundableVout = lockMoreCollateral_4_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === refundableAddress)
+        const lockMoreCollateral_4_SeizableVout = lockMoreCollateral_4_Tx._raw.data.vout.find(vout => vout.scriptPubKey.addresses[0] === seizableAddress)
+
+        const lockMoreCollateral_4_BitcoinJsTx = bitcoinjs.Transaction.fromHex(lockMoreCollateral_4_TxRaw)
+        const lockMoreCollateral_4_Vin = ensure0x(lockMoreCollateral_4_BitcoinJsTx.getVin())
+        const lockMoreCollateral_4_Vout = ensure0x(lockMoreCollateral_4_BitcoinJsTx.getVout())
+
+        await bitcoin.client.chain.generateBlock(1)
+
+        const refundableInputIndex_1 = 0
+        const refundableOutputIndex_1 = lockMoreCollateral_1_RefundableVout.n
+
+        const refundableInputIndex_2 = 0
+        const refundableOutputIndex_2 = lockMoreCollateral_2_RefundableVout.n
+
+        const refundableInputIndex_3 = 0
+        const refundableOutputIndex_3 = lockMoreCollateral_3_RefundableVout.n
+
+        const refundableInputIndex_4 = 0
+        const refundableOutputIndex_4 = lockMoreCollateral_4_RefundableVout.n
+
+        const seizableInputIndex_1 = 0
+        const seizableOutputIndex_1 = lockMoreCollateral_1_SeizableVout.n
+
+        const seizableInputIndex_2 = 0
+        const seizableOutputIndex_2 = lockMoreCollateral_2_SeizableVout.n
+
+        const seizableInputIndex_3 = 0
+        const seizableOutputIndex_3 = lockMoreCollateral_3_SeizableVout.n
+
+        const seizableInputIndex_4 = 0
+        const seizableOutputIndex_4 = lockMoreCollateral_4_SeizableVout.n
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #1 ONE CONFIRMATION
+        const fillRefundRequest_1_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, refundRequestIDOneConf, refundableInputIndex_1, refundableOutputIndex_1)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, refundRequestIDOneConf, refundableInputIndex_1, refundableOutputIndex_1)
+        expect(fillRefundRequest_1_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingRefundableCollateral_1 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingRefundableCollateral_1 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingRefundableCollateral_1 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingRefundableCollateral_1.toNumber()).to.equal(refundableValue + seizableValue + refundableValue)
+        expect(CDIValueAfterOneAddingRefundableCollateral_1.toNumber()).to.equal(1)
+        expect(CDFIValueAfterOneAddingRefundableCollateral_1.toNumber()).to.equal(0)
+
+        await increaseTime(toSecs({ hours: 1 }))
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #2 ONE CONFIRMATION
+        const fillRefundRequest_2_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, refundRequestIDOneConf, refundableInputIndex_2, refundableOutputIndex_2)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, refundRequestIDOneConf, refundableInputIndex_2, refundableOutputIndex_2)
+        expect(fillRefundRequest_2_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingRefundableCollateral_2 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingRefundableCollateral_2 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingRefundableCollateral_2 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingRefundableCollateral_2.toNumber()).to.equal(collateralValueAfterOneAddingRefundableCollateral_1.toNumber() + refundableValue)
+        expect(CDIValueAfterOneAddingRefundableCollateral_2.toNumber()).to.equal(2)
+        expect(CDFIValueAfterOneAddingRefundableCollateral_2.toNumber()).to.equal(0)
+
+        await increaseTime(toSecs({ hours: 1 }))
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #3 ONE CONFIRMATION
+        const fillRefundRequest_3_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, refundRequestIDOneConf, refundableInputIndex_3, refundableOutputIndex_3)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, refundRequestIDOneConf, refundableInputIndex_3, refundableOutputIndex_3)
+        expect(fillRefundRequest_3_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingRefundableCollateral_3 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingRefundableCollateral_3 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingRefundableCollateral_3 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingRefundableCollateral_3.toNumber()).to.equal(collateralValueAfterOneAddingRefundableCollateral_2.toNumber() + refundableValue)
+        expect(CDIValueAfterOneAddingRefundableCollateral_3.toNumber()).to.equal(3)
+        expect(CDFIValueAfterOneAddingRefundableCollateral_3.toNumber()).to.equal(0)
+
+        await increaseTime(toSecs({ hours: 1 }))
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #1 ONE CONFIRMATION
+        const fillSeizeRequest_1_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, seizeRequestIDOneConf, seizableInputIndex_1, seizableOutputIndex_1)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, seizeRequestIDOneConf, seizableInputIndex_1, seizableOutputIndex_1)
+        expect(fillSeizeRequest_1_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingSeizableCollateral_1 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingSeizableCollateral_1 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingSeizableCollateral_1 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingSeizableCollateral_1.toNumber()).to.equal(collateralValueAfterOneAddingRefundableCollateral_3.toNumber() + seizableValue)
+        expect(CDIValueAfterOneAddingSeizableCollateral_1.toNumber()).to.equal(4)
+        expect(CDFIValueAfterOneAddingSeizableCollateral_1.toNumber()).to.equal(0)
+
+        await increaseTime(toSecs({ hours: 1 }))
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #2 ONE CONFIRMATION
+        const fillSeizeRequest_2_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, seizeRequestIDOneConf, seizableInputIndex_2, seizableOutputIndex_2)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, seizeRequestIDOneConf, seizableInputIndex_2, seizableOutputIndex_2)
+        expect(fillSeizeRequest_2_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingSeizableCollateral_2 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingSeizableCollateral_2 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingSeizableCollateral_2 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingSeizableCollateral_2.toNumber()).to.equal(refundableValue + seizableValue) // should go back to original collateral amount since more than 4 hours has passed
+        expect(CDIValueAfterOneAddingSeizableCollateral_2.toNumber()).to.equal(5)
+        expect(CDFIValueAfterOneAddingSeizableCollateral_2.toNumber()).to.equal(0)
+
+        await increaseTime(toSecs({ hours: 1 }))
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #3 ONE CONFIRMATION
+        const fillSeizeRequest_3_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, seizeRequestIDOneConf, seizableInputIndex_3, seizableOutputIndex_3)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, seizeRequestIDOneConf, seizableInputIndex_3, seizableOutputIndex_3)
+        expect(fillSeizeRequest_3_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingSeizableCollateral_3 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingSeizableCollateral_3 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingSeizableCollateral_3 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingSeizableCollateral_3.toNumber()).to.equal(refundableValue + seizableValue)
+        expect(CDIValueAfterOneAddingSeizableCollateral_3.toNumber()).to.equal(6)
+        expect(CDFIValueAfterOneAddingSeizableCollateral_3.toNumber()).to.equal(0)
+
+        await bitcoin.client.chain.generateBlock(5)
+
+        await increaseTime(toSecs({ hours: 5 }))
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #3 SIX CONFIRMATION
+        const fillSeizeRequest_3_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, seizeRequestIDSixConf, seizableInputIndex_3, seizableOutputIndex_3)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, seizeRequestIDSixConf, seizableInputIndex_3, seizableOutputIndex_3)
+        expect(fillSeizeRequest_3_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingSeizableCollateral_3 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingSeizableCollateral_3 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingSeizableCollateral_3 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingSeizableCollateral_3.toNumber()).to.equal(collateralValueAfterOneAddingSeizableCollateral_3.toNumber() + seizableValue)
+        expect(CDIValueAfterSixAddingSeizableCollateral_3.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingSeizableCollateral_3.toNumber()).to.equal(0)
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #2 SIX CONFIRMATION
+        const fillSeizeRequest_2_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, seizeRequestIDSixConf, seizableInputIndex_2, seizableOutputIndex_2)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, seizeRequestIDSixConf, seizableInputIndex_2, seizableOutputIndex_2)
+        expect(fillSeizeRequest_2_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingSeizableCollateral_2 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingSeizableCollateral_2 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingSeizableCollateral_2 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingSeizableCollateral_2.toNumber()).to.equal(collateralValueAfterSixAddingSeizableCollateral_3.toNumber() + seizableValue)
+        expect(CDIValueAfterSixAddingSeizableCollateral_2.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingSeizableCollateral_2.toNumber()).to.equal(0)
+
+        // SPV FILL REQUEST SEIZABLE COLLATERAL #1 SIX CONFIRMATION
+        const fillSeizeRequest_1_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, seizeRequestIDSixConf, seizableInputIndex_1, seizableOutputIndex_1)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, seizeRequestIDSixConf, seizableInputIndex_1, seizableOutputIndex_1)
+        expect(fillSeizeRequest_1_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingSeizableCollateral_1 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingSeizableCollateral_1 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingSeizableCollateral_1 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingSeizableCollateral_1.toNumber()).to.equal(collateralValueAfterSixAddingSeizableCollateral_2.toNumber() + seizableValue)
+        expect(CDIValueAfterSixAddingSeizableCollateral_1.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingSeizableCollateral_1.toNumber()).to.equal(0)
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #3 SIX CONFIRMATION
+        const fillRefundRequest_3_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, refundRequestIDSixConf, refundableInputIndex_3, refundableOutputIndex_3)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_3_TxHashForProof, lockMoreCollateral_3_Vin, lockMoreCollateral_3_Vout, refundRequestIDSixConf, refundableInputIndex_3, refundableOutputIndex_3)
+        expect(fillRefundRequest_3_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingRefundableCollateral_3 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingRefundableCollateral_3 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingRefundableCollateral_3 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingRefundableCollateral_3.toNumber()).to.equal(collateralValueAfterSixAddingSeizableCollateral_1.toNumber() + refundableValue)
+        expect(CDIValueAfterSixAddingRefundableCollateral_3.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingRefundableCollateral_3.toNumber()).to.equal(0)
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #2 SIX CONFIRMATION
+        const fillRefundRequest_2_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, refundRequestIDSixConf, refundableInputIndex_2, refundableOutputIndex_2)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_2_TxHashForProof, lockMoreCollateral_2_Vin, lockMoreCollateral_2_Vout, refundRequestIDSixConf, refundableInputIndex_2, refundableOutputIndex_2)
+        expect(fillRefundRequest_2_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingRefundableCollateral_2 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingRefundableCollateral_2 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingRefundableCollateral_2 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingRefundableCollateral_2.toNumber()).to.equal(collateralValueAfterSixAddingRefundableCollateral_3.toNumber() + refundableValue)
+        expect(CDIValueAfterSixAddingRefundableCollateral_2.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingRefundableCollateral_2.toNumber()).to.equal(0)
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #1 SIX CONFIRMATION
+        const fillRefundRequest_1_SixConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, refundRequestIDSixConf, refundableInputIndex_1, refundableOutputIndex_1)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_1_TxHashForProof, lockMoreCollateral_1_Vin, lockMoreCollateral_1_Vout, refundRequestIDSixConf, refundableInputIndex_1, refundableOutputIndex_1)
+        expect(fillRefundRequest_1_SixConfSuccess).to.equal(true)
+
+        const collateralValueAfterSixAddingRefundableCollateral_1 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterSixAddingRefundableCollateral_1 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterSixAddingRefundableCollateral_1 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterSixAddingRefundableCollateral_1.toNumber()).to.equal(collateralValueAfterSixAddingRefundableCollateral_2.toNumber() + refundableValue)
+        expect(CDIValueAfterSixAddingRefundableCollateral_1.toNumber()).to.equal(6)
+        expect(CDFIValueAfterSixAddingRefundableCollateral_1.toNumber()).to.equal(6)
+
+        await increaseTime(toSecs({ hours: 5 }))
+
+        // SPV FILL REQUEST REFUNDABLE COLLATERAL #4 ONE CONFIRMATION
+        const fillRefundRequest_4_OneConfSuccess = await this.onDemandSpv.fillRequest.call(lockMoreCollateral_4_TxHashForProof, lockMoreCollateral_4_Vin, lockMoreCollateral_4_Vout, refundRequestIDOneConf, refundableInputIndex_4, refundableOutputIndex_4)
+        await this.onDemandSpv.fillRequest(lockMoreCollateral_4_TxHashForProof, lockMoreCollateral_4_Vin, lockMoreCollateral_4_Vout, refundRequestIDOneConf, refundableInputIndex_4, refundableOutputIndex_4)
+        expect(fillRefundRequest_4_OneConfSuccess).to.equal(true)
+
+        const collateralValueAfterOneAddingRefundableCollateral_4 = await this.loans.collateral.call(this.loan)
+        const CDIValueAfterOneAddingRefundableCollateral_4 = await this.loans.collateralDepositIndex.call(this.loan)
+        const CDFIValueAfterOneAddingRefundableCollateral_4 = await this.loans.collateralDepositFinalizedIndex.call(this.loan)
+
+        expect(collateralValueAfterOneAddingRefundableCollateral_4.toNumber()).to.equal(collateralValueAfterSixAddingRefundableCollateral_1.toNumber() + refundableValue)
+        expect(CDIValueAfterOneAddingRefundableCollateral_4.toNumber()).to.equal(7)
+        expect(CDFIValueAfterOneAddingRefundableCollateral_4.toNumber()).to.equal(6)
+
+        const collateralValueAfterTimeout = await this.loans.collateral.call(this.loan)
+
+        assert.isAbove(parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_1).toFixed()), parseInt(BigNumber(collateralValueBeforeAddingCollateral).toFixed()))
+        assert.isAbove(parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_2).toFixed()), parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_1).toFixed()))
+        assert.isAbove(parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_3).toFixed()), parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_2).toFixed()))
+        assert.isAbove(parseInt(BigNumber(collateralValueAfterOneAddingSeizableCollateral_1).toFixed()), parseInt(BigNumber(collateralValueAfterOneAddingRefundableCollateral_3).toFixed()))
+        assert.isBelow(parseInt(BigNumber(collateralValueAfterOneAddingSeizableCollateral_2).toFixed()), parseInt(BigNumber(collateralValueAfterOneAddingSeizableCollateral_1).toFixed()))
+        assert.isBelow(parseInt(BigNumber(collateralValueAfterOneAddingSeizableCollateral_3).toFixed()), parseInt(BigNumber(collateralValueAfterOneAddingSeizableCollateral_1).toFixed()))
+      })
     })
 
     describe('Locking collateral multiple times', function() {
-      it('should allow adding of temporary refundable collateral 200 times without running out of gas', async function() {
+      it('should allow adding of temporary refundable collateral 100 times without running out of gas', async function() {
         this.timeout(9900000);
 
         const { colParams, owedForLoan, lockTxHash } = await lockApproveWithdraw(this.loans, this.loan, btcPrice, unit, col, borrower, borSecs[0])


### PR DESCRIPTION
### Description

This PR sheds some light on the concerns around gas usage with the loop inside of `Loans.spv`.

This function is called by the `onDemandSpv` Request Manager, who provides Bitcoin transaction proofs to the Ethereum chain.

The reason this loop exists is for the following case:

Say you have 3 new adding Bitcoin transactions that were created. 

And SPV request will be provided by the `onDemandSpv` Request Manager for the 1st confirmation, and the 6th confirmations. However, we cannot necessarily assume that these will occur in order. 

For example, say the following request fulfillments are added. 

`Add Collateral 1 Conf #1`
`Add Collateral 1 Conf #2`
`Add collateral 1 Conf #3`

The user now waits for the 6 confirmation requests to come in. But say they come in, in the opposit order 

`Add Collateral 6 Confs #3`
`Add Collateral 6 Confs #2`
`Add Collateral 6 Confs #1`

In this case, the finalized index needs to be updated, but it will be updated in the opposite order. 

Therefore, in this case, when the tx request reaches 6 confs #1, the for loop will update the finalized index for 1, 2, and 3. 

### Gas usage
Here are the results, in the case that x transactions have the 1 conf added, and then x 6 conf transactions are provided out of order. 

100: `740398` gas
500: `3143102` gas
1000: `6199347` gas

### Submission Checklist :pencil:

- [x] Fix for loop in `Loans.spv` to ensure finalized index is updated
- [x] Add tests for `collateralDepositIndex` and `collateralDepositFinalizedIndex` are update properly