### PR TITLE
Prevent duplicate timestamp for same borrower

### DIFF
--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -51,6 +51,7 @@ contract Loans is DSMath {
     mapping (bytes32 => uint256)                               public collateralDepositIndex;
     mapping (bytes32 => uint256)                               public collateralDepositFinalizedIndex;
 
+    mapping (address => mapping(uint256 => bool))              public addressToTimestamp;
 
     ERC20 public token; // ERC20 Debt Stablecoin
     uint256 public decimals;
@@ -387,6 +388,8 @@ contract Loans is DSMath {
         bytes32             fundIndex_
     ) external returns (bytes32 loan) {
         if (fundIndex_ != bytes32(0)) { require(funds.lender(fundIndex_) == usrs_[1]); }
+        require(!addressToTimestamp[usrs_[0]][vals_[6]]);
+
         loanIndex = add(loanIndex, 1);
         loan = bytes32(loanIndex);
         loans[loan].createdAt        = now;
@@ -406,6 +409,7 @@ contract Loans is DSMath {
         secretHashes[loan].set       = false;
         borrowerLoans[usrs_[0]].push(bytes32(loanIndex));
         lenderLoans[usrs_[1]].push(bytes32(loanIndex));
+        addressToTimestamp[usrs_[0]][vals_[6]] = true;
 
         emit Create(loan);
     }

--- a/test/funds.js
+++ b/test/funds.js
@@ -34,6 +34,17 @@ const BTC_TO_SAT = 10**8
 
 const stablecoins = [ { name: 'SAI', unit: 'ether' }, { name: 'USDC', unit: 'mwei' } ]
 
+const mockDateNow = () => {
+  let current = Date.now()
+
+  return () => {
+    current += 5000;
+    return current;
+  }
+}
+
+global.Date.now = mockDateNow();
+
 async function getContracts(stablecoin) {
   if (stablecoin == 'SAI') {
     const funds = await Funds.deployed();

--- a/test/interestDecrease.js
+++ b/test/interestDecrease.js
@@ -34,6 +34,17 @@ const BTC_TO_SAT = 10**8
 
 console.info = () => {} // Silence the Deprecation Warning
 
+const mockDateNow = () => {
+  let current = Date.now()
+
+  return () => {
+    current += 5000;
+    return current;
+  }
+}
+
+global.Date.now = mockDateNow();
+
 const stablecoins = [ { name: 'SAI', unit: 'ether' }, { name: 'USDC', unit: 'mwei' } ]
 
 async function getContracts(stablecoin) {

--- a/test/interestIncrease.js
+++ b/test/interestIncrease.js
@@ -34,6 +34,17 @@ const BTC_TO_SAT = 10**8
 
 console.info = () => {} // Silence the Deprecation Warning
 
+const mockDateNow = () => {
+  let current = Date.now()
+
+  return () => {
+    current += 5000;
+    return current;
+  }
+}
+
+global.Date.now = mockDateNow();
+
 const stablecoins = [ { name: 'SAI', unit: 'ether' }, { name: 'USDC', unit: 'mwei' } ]
 
 async function getContracts(stablecoin) {

--- a/test/loans.js
+++ b/test/loans.js
@@ -333,6 +333,16 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender2, arbiter ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
+        const fundId = numToBytes32(1)
+
+        await expectRevert(this.loans.create(loanExpiration, usrs, vals, fundId), 'VM Exception while processing transaction: revert')
+      })
+
+      it('should fail if requestTimestamp is duplicated', async function() {
+        const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
+        const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
+        const usrs = [ borrower, lender, arbiter ]
         const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
         const fundId = numToBytes32(1)
 
@@ -345,7 +355,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -360,7 +370,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -375,7 +385,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -391,7 +401,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -418,7 +428,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -441,7 +451,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -459,7 +469,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -477,7 +487,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -625,7 +635,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -1130,7 +1140,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -1166,7 +1176,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -1258,7 +1268,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)
@@ -1282,7 +1292,7 @@ stablecoins.forEach((stablecoin) => {
         const { loanExpiration, principal, interest, penalty, fee, liquidationRatio, requestTimestamp } = await this.loans.loans.call(this.loan)
         const { refundableCollateral, seizableCollateral } = await this.loans.collaterals.call(this.loan)
         const usrs = [ borrower, lender, arbiter ]
-        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp ]
+        const vals = [ principal, interest, penalty, fee, BigNumber(refundableCollateral).plus(seizableCollateral).toFixed(), liquidationRatio, requestTimestamp + 1 ]
         const fundId = numToBytes32(0)
 
         const loan = await this.loans.create.call(loanExpiration, usrs, vals, fundId)

--- a/test/loans.js
+++ b/test/loans.js
@@ -34,6 +34,17 @@ const BTC_TO_SAT = 10**8
 
 const stablecoins = [ { name: 'SAI', unit: 'ether' }, { name: 'USDC', unit: 'mwei' } ]
 
+const mockDateNow = () => {
+  let current = Date.now()
+
+  return () => {
+    current += 5000;
+    return current;
+  }
+}
+
+global.Date.now = mockDateNow();
+
 async function getContracts(stablecoin) {
   if (stablecoin == 'SAI') {
     const funds = await Funds.deployed();

--- a/test/sales.js
+++ b/test/sales.js
@@ -38,6 +38,17 @@ const stablecoins = [
   { name: 'USDC', unit: 'mwei', multiplier: SZABO, divisor: WAD, precision: 10 }
 ]
 
+const mockDateNow = () => {
+  let current = Date.now()
+
+  return () => {
+    current += 5000;
+    return current;
+  }
+}
+
+global.Date.now = mockDateNow();
+
 async function getContracts(stablecoin) {
   if (stablecoin == 'SAI') {
     const funds = await Funds.deployed();


### PR DESCRIPTION
## Description

Prevent the creation of loan requests with a `requestTimestamp` that has been used in another loan request by the same borrower.

This prevents an attack by which the lender agent would reuse a `requestTimestamp` and have the borrower regenerate the same secrets. 

### Submission Checklist :pencil:

- [x] Require different timestamp
- [x] Update tests
- [x] Create a new test