### PR TITLE
Ensure default value ensureNotZero is changed to is MAX_LOAN_LENGTH

### DIFF
--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -386,7 +386,7 @@ contract Funds is DSMath, ALCompound {
         // #ELSE:
         // require(funds[fundOwner[msg.sender]].lender != msg.sender); // Only allow one loan fund per address
         // #ENDIF
-        require(ensureNotZero(maxLoanDur_, false) <= MAX_LOAN_LENGTH && ensureNotZero(fundExpiry_, true) <= now + MAX_LOAN_LENGTH); // Make sure someone can't request a loan for eternity
+        require(ensureNotZero(maxLoanDur_, false) < MAX_LOAN_LENGTH && ensureNotZero(fundExpiry_, true) < now + MAX_LOAN_LENGTH); // Make sure someone can't request a loan for eternity
         if (!compoundSet) { require(compoundEnabled_ == false); }
         fundIndex = add(fundIndex, 1);
         fund = bytes32(fundIndex);
@@ -435,7 +435,7 @@ contract Funds is DSMath, ALCompound {
         // #ELSE:
         // require(funds[fundOwner[msg.sender]].lender != msg.sender); // Only allow one loan fund per address
         // #ENDIF
-        require(ensureNotZero(maxLoanDur_, false) <= MAX_LOAN_LENGTH && ensureNotZero(fundExpiry_, true) <= now + MAX_LOAN_LENGTH); // Make sure someone can't request a loan for eternity
+        require(ensureNotZero(maxLoanDur_, false) < MAX_LOAN_LENGTH && ensureNotZero(fundExpiry_, true) < now + MAX_LOAN_LENGTH); // Make sure someone can't request a loan for eternity
         if (!compoundSet) { require(compoundEnabled_ == false); }
         fundIndex = add(fundIndex, 1);
         fund = bytes32(fundIndex);

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -726,7 +726,7 @@ contract Funds is DSMath, ALCompound {
      * @param value The value to be sanity checked
      */
     function ensureNotZero(uint256 value) public pure returns (uint256) {
-        if (value == 0) { return MAX_UINT_256; }
+        if (value == 0) { return MAX_LOAN_LENGTH; }
         else            { return value; }
     }
 

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -314,7 +314,7 @@ contract Loans is DSMath {
     }
 
     function minSeizableCollateralValue(bytes32 loan) public view returns (uint256) {
-        (bytes32 val, bool set) = med.peek();
+        (bytes32 val,) = med.peek();
         uint256 price = uint(val);
         return div(wdiv(dmul(add(principal(loan), interest(loan))), price), div(WAD, COL));
     }

--- a/test/funds.js
+++ b/test/funds.js
@@ -1193,6 +1193,26 @@ stablecoins.forEach((stablecoin) => {
       })
     })
 
+    describe('ensureNotZero', function() {
+      it('should convert 0 to MAX_LOAN_LENGTH if addNow bool is false', async function() {
+        const MAX_LOAN_LENGTH = await this.funds.MAX_LOAN_LENGTH.call()
+
+        const ensureNotZeroValue = await this.funds.ensureNotZero.call(0, false)
+
+        expect(BigNumber(MAX_LOAN_LENGTH).toFixed()).to.equal(BigNumber(ensureNotZeroValue).toFixed())
+      })
+
+      it('should convert 0 to MAX_LOAN_LENGTH + now if addNow bool is true', async function() {
+        const currentTime = Math.floor(Date.now() / 1000)
+
+        const MAX_LOAN_LENGTH = await this.funds.MAX_LOAN_LENGTH.call()
+        const ensureNotZeroValue = await this.funds.ensureNotZero.call(0, true)
+
+        assert.isAbove(BigNumber(currentTime).plus(MAX_LOAN_LENGTH).plus(1e8).toNumber(), BigNumber(ensureNotZeroValue).toNumber())
+        assert.isBelow(BigNumber(currentTime).plus(MAX_LOAN_LENGTH).minus(1e8).toNumber(), BigNumber(ensureNotZeroValue).toNumber())
+      })
+    })
+
     describe('setLoans', function() {
       it('should not allow setLoans to be called twice', async function() {
         await expectRevert(this.funds.setLoans(this.loans.address), 'VM Exception while processing transaction: revert')


### PR DESCRIPTION
### Description

This PR ensures the default value returned by `Funds.ensureNotZero` is `MAX_LOAN_LENGTH` not `2**256-1`

### Submission Checklist :pencil:

- [x] Ensure default value returned by `Funds.ensureNotZero` is `MAX_LOAN_LENGTH` not `2**256-1`
