### PR TITLE
Lock solidity pragma version to 0.5.10

### DIFF
--- a/contracts/ALCompound.sol
+++ b/contracts/ALCompound.sol
@@ -1,6 +1,6 @@
-import './DSMath.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import './DSMath.sol';
 
 interface CTokenInterface {
     function redeem(uint redeemTokens) external returns (uint);

--- a/contracts/Bytes.sol
+++ b/contracts/Bytes.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 contract Bytes {
     function scriptNumSize(uint256 i) public pure returns (uint256) {

--- a/contracts/DSMath.sol
+++ b/contracts/DSMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 contract DSMath {
     function add(uint x, uint y) internal pure returns (uint z) {

--- a/contracts/ExampleDaiCoin.sol
+++ b/contracts/ExampleDaiCoin.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract ExampleDaiCoin is ERC20 {
   string public name = "ExampleDAICoin"; 

--- a/contracts/ExamplePausableSaiCoin.sol
+++ b/contracts/ExamplePausableSaiCoin.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20Pausable.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20Pausable.sol';
 
 contract ExamplePausableSaiCoin is ERC20Pausable {
   string public name = "ExamplePausableSAICoin"; 

--- a/contracts/ExampleSaiCoin.sol
+++ b/contracts/ExampleSaiCoin.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract ExampleSaiCoin is ERC20 {
   string public name = "ExampleSAICoin"; 

--- a/contracts/ExampleUsdcCoin.sol
+++ b/contracts/ExampleUsdcCoin.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract ExampleUsdcCoin is ERC20 {
   string public name = "ExampleUsdcCoin"; 

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -1,10 +1,10 @@
+pragma solidity 0.5.10;
+
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 import './Loans.sol';
 import './ALCompound.sol';
-
-pragma solidity ^0.5.10;
 
 contract Funds is DSMath, ALCompound {
     Loans loans;

--- a/contracts/FundsInterface.sol
+++ b/contracts/FundsInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 interface FundsInterface {
     function lender(bytes32) external view returns (address);

--- a/contracts/ISPVInterfaces.sol
+++ b/contracts/ISPVInterfaces.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 /// @title      ISPVConsumer
 /// @author     Summa (https://summa.one)

--- a/contracts/ISPVRequestManager.sol
+++ b/contracts/ISPVRequestManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 import './DSMath.sol';
 import {BytesLib} from "@summa-tx/bitcoin-spv-sol/contracts/BytesLib.sol";

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -1,3 +1,5 @@
+pragma solidity 0.5.10;
+
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
@@ -10,8 +12,6 @@ import './P2WSHInterface.sol';
 import './ISPVRequestManager.sol';
 import './DSMath.sol';
 import './Medianizer.sol';
-
-pragma solidity ^0.5.10;
 
 contract Loans is DSMath {
     FundsInterface funds;
@@ -103,7 +103,7 @@ contract Loans is DSMath {
      * @member arbiterPubKey Arbiter Bitcoin Public Key
      *
      *         Note: This struct is unnecessary for the Ethereum
-     *               contract itself, but is used as a point of 
+     *               contract itself, but is used as a point of
      *               reference for generating the correct P2WSH for
      *               locking Bitcoin collateral
      */
@@ -384,7 +384,7 @@ contract Loans is DSMath {
         onDemandSpv = onDemandSpv_;
     }
     // ======================================================================
-    
+
     /**
      * @notice Creates a new loan agreement
      * @param loanExpiration_ The timestamp for the end of the loan

--- a/contracts/LoansInterface.sol
+++ b/contracts/LoansInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 interface LoansInterface {
     function secretHashes(bytes32) external view returns (bytes32, bytes32, bytes32, bytes32, bytes32, bool);

--- a/contracts/Medianizer.sol
+++ b/contracts/Medianizer.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract Medianizer {
     function peek() public view returns (bytes32, bool);

--- a/contracts/MedianizerExample.sol
+++ b/contracts/MedianizerExample.sol
@@ -1,6 +1,6 @@
-import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+pragma solidity 0.5.10;
 
-pragma solidity ^0.5.10;
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract MedianizerExample {
     bool    has;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 contract Migrations {
   address public owner;

--- a/contracts/P2WSH.sol
+++ b/contracts/P2WSH.sol
@@ -1,7 +1,7 @@
+pragma solidity 0.5.10;
+
 import './Bytes.sol';
 import './LoansInterface.sol';
-
-pragma solidity ^0.5.10;
 
 contract P2WSH is Bytes {
   LoansInterface loans;

--- a/contracts/P2WSHInterface.sol
+++ b/contracts/P2WSHInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 interface P2WSHInterface {
   function getP2WSH(bytes32 loan, bool sez) external view returns (bytes memory, bytes32);

--- a/contracts/Sales.sol
+++ b/contracts/Sales.sol
@@ -1,11 +1,11 @@
+pragma solidity 0.5.10;
+
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 import './Loans.sol';
 import './Medianizer.sol';
 import './DSMath.sol';
-
-pragma solidity ^0.5.10;
 
 contract Sales is DSMath {
     FundsInterface funds;

--- a/contracts/SalesInterface.sol
+++ b/contracts/SalesInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity 0.5.10;
 
 interface SalesInterface {
     function saleIndexByLoan(bytes32, uint256) external returns(bytes32);


### PR DESCRIPTION
### Description

This PR locks the solidity pragma version to `0.5.10` for all oracle contracts. This is to prevent unexpected behaviour in the future. 

### Submission Checklist :pencil:

- [x] Lock the solidity pragma to `0.5.10` for all contracts
