### PR TITLE
Make spv optional and allow unsetOnDemandSpv

### DIFF
--- a/contracts/Collateral.sol
+++ b/contracts/Collateral.sol
@@ -10,8 +10,8 @@ import './DSMath.sol';
 
 contract Collateral is DSMath {
     P2WSHInterface p2wsh;
-    ISPVRequestManager onDemandSpv;
     Loans loans;
+    ISPVRequestManager public onDemandSpv;
 
     uint256 public constant ADD_COLLATERAL_EXPIRY = 4 hours;
 
@@ -113,6 +113,12 @@ contract Collateral is DSMath {
         require(address(onDemandSpv) == address(0), "Loans.setOnDemandSpv: The OnDemandSpv address has already been set");
         require(address(onDemandSpv_) != address(0), "Loans.setOnDemandSpv: OnDemandSpv address must be non-zero");
         onDemandSpv = onDemandSpv_;
+    }
+
+    function unsetOnDemandSpv() external {
+        require(msg.sender == deployer, "Loans.setOnDemandSpv: Only the deployer can perform this");
+        require(address(onDemandSpv) != address(0), "Loans.setOnDemandSpv: The OnDemandSpv address has not been set");
+        onDemandSpv = ISPVRequestManager(address(0));
     }
 
     function setCollateral(bytes32 loan, uint256 refundableCollateral_, uint256 seizableCollateral_) external {

--- a/contracts/CollateralInterface.sol
+++ b/contracts/CollateralInterface.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.5.10;
 
 interface CollateralInterface {
+    function onDemandSpv() external view returns(address);
     function collateral(bytes32 loan) external view returns (uint256);
     function refundableCollateral(bytes32 loan) external view returns (uint256);
     function seizableCollateral(bytes32 loan) external view returns (uint256);

--- a/contracts/Funds.sol
+++ b/contracts/Funds.sol
@@ -370,7 +370,7 @@ contract Funds is DSMath, ALCompound {
      * @param addr_ The address of the user
      * @return The length of the secretHashes array for user address
      */
-    function secretHashesCount(address addr_) external view returns (uint256) {
+    function secretHashesCount(address addr_) public view returns (uint256) {
         return secretHashes[addr_].length;
     }
 
@@ -851,6 +851,7 @@ contract Funds is DSMath, ALCompound {
      */
     function getSecretHashesForLoan(address addr_) private returns (bytes32[4] memory) {
         secretHashIndex[addr_] = add(secretHashIndex[addr_], 4);
+        require(secretHashesCount(addr_) >= secretHashIndex[addr_], "Funds.getSecretHashesForLoan: Not enough secrets generated");
         return [
             secretHashes[addr_][sub(secretHashIndex[addr_], 4)],
             secretHashes[addr_][sub(secretHashIndex[addr_], 3)],

--- a/contracts/Loans.sol
+++ b/contracts/Loans.sol
@@ -451,7 +451,7 @@ contract Loans is DSMath {
         require(token.transfer(loans[loan].borrower, principal(loan)), "Loans.withdraw: Failed to transfer tokens");
 
         secretHashes[loan].withdrawSecret = secretA1;
-        col.requestSpv(loan);
+        if (address(col.onDemandSpv()) != address(0)) {col.requestSpv(loan);}
     }
 
     /**
@@ -471,7 +471,7 @@ contract Loans is DSMath {
         repayments[loan] = add(amount, repayments[loan]);
         if (repaid(loan) == owedForLoan(loan)) {
             bools[loan].paid = true;
-            col.cancelSpv(loan);
+            if (address(col.onDemandSpv()) != address(0)) {col.cancelSpv(loan);}
         }
     }
 
@@ -602,6 +602,6 @@ contract Loans is DSMath {
             bools[loan].sale = true;
             require(token.transfer(address(sales), repaid(loan)), "Loans.liquidate: Token transfer to Sales contract failed");
         }
-        col.cancelSpv(loan);
+        if (address(col.onDemandSpv()) != address(0)) {col.cancelSpv(loan);}
     }
 }

--- a/test/loans.js
+++ b/test/loans.js
@@ -387,6 +387,108 @@ stablecoins.forEach((stablecoin) => {
       })
     })
 
+    describe('unsetOnDemandSpv', function() {
+      it('should set onDemandSpv address to null', async function() {
+        const decimal = stablecoin.unit === 'ether' ? '18' : '6'
+
+        const funds = await Funds.new(this.token.address, decimal)
+        const loans = await Loans.new(funds.address, this.med.address, this.token.address, decimal)
+        const sales = await Sales.new(loans.address, funds.address, this.med.address, this.token.address)
+
+        await funds.setLoans(loans.address)
+        await loans.setSales(sales.address)
+
+        const onDemandSpv = await ISPVRequestManager.deployed()
+
+        const collateral = await Collateral.new(loans.address)
+
+        await collateral.setOnDemandSpv(onDemandSpv.address)
+
+        await collateral.unsetOnDemandSpv()
+
+        const onDemandSpvAddressAfter = await collateral.onDemandSpv.call()
+
+        expect(onDemandSpvAddressAfter).to.equal('0x0000000000000000000000000000000000000000')
+      })
+
+      it('should allow loan to be created and repaid without onDemandSpv set', async function() {
+        const decimal = stablecoin.unit === 'ether' ? '18' : '6'
+
+        const funds = await Funds.new(this.token.address, decimal)
+        const loans = await Loans.new(funds.address, this.med.address, this.token.address, decimal)
+        const sales = await Sales.new(loans.address, funds.address, this.med.address, this.token.address)
+
+        await funds.setLoans(loans.address)
+        await loans.setSales(sales.address)
+
+        const p2wsh = await P2WSH.deployed()
+
+        const collateral = await Collateral.new(loans.address)
+
+        await collateral.setP2WSH(p2wsh.address)
+
+        await loans.setCollateral(collateral.address)
+
+        const onDemandSpvAddress = await collateral.onDemandSpv.call()
+        expect(onDemandSpvAddress).to.equal('0x0000000000000000000000000000000000000000')
+
+        const fundParams = [
+          toWei('1', unit),
+          toWei('100', unit),
+          toSecs({days: 1}),
+          toSecs({days: 366}),
+          YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+          toWei('1.5', 'gether'), // 150% collateralization ratio
+          toWei(rateToSec('16.5'), 'gether'), // 16.50%
+          toWei(rateToSec('3'), 'gether'), //  3.00%
+          toWei(rateToSec('0.75'), 'gether'), //  0.75%
+          arbiter,
+          false,
+          0
+        ]
+
+        const fund = await funds.createCustom.call(...fundParams)
+        await funds.createCustom(...fundParams)
+
+        // Generate arbiter secret hashes
+        await funds.generate(arbiterSechs, { from: arbiter })
+
+        // Push funds to loan fund
+        await this.token.approve(funds.address, toWei('100', unit))
+        await funds.deposit(fund, toWei('100', unit))
+
+        // Pull from loan
+        const loanParams = [
+          fund,
+          borrower,
+          toWei(loanReq.toString(), unit),
+          col,
+          toSecs({days: 2}),
+          Math.floor(Date.now() / 1000),
+          [ ...borSechs, ...lendSechs ],
+          ensure0x(borpubk),
+          ensure0x(lendpubk)
+        ]
+
+        const loan = await funds.request.call(...loanParams)
+        await funds.request(...loanParams)
+
+        await loans.approve(loan)
+
+        await loans.withdraw(loan, borSecs[0], { from: borrower })
+
+        // Send funds to borrower so they can repay full
+        await this.token.transfer(borrower, toWei('1', unit))
+
+        await this.token.approve(loans.address, toWei('100', unit), { from: borrower })
+
+        const owedForLoan = await loans.owedForLoan.call(loan)
+        await loans.repay(loan, owedForLoan, { from: borrower })
+
+        await loans.accept(loan, lendSecs[0]) // accept loan repayment
+      })
+    })
+
     describe('setCollateral', function() {
       it('should fail if msg.sender is not deployer', async function() {
         const decimal = stablecoin.unit === 'ether' ? '18' : '6'


### PR DESCRIPTION
### Description

This PR makes onDemandSpv optional within the contracts and can be enables or disabled by admin. 

### Submission Checklist :pencil:

- [x] Add logic for optional `onDemandSpv`
- [x] Add `Collateral.unsetOnDemandSpv`
