### PR TITLE
Update linux distro for travis to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: node_js
 node_js:


### PR DESCRIPTION
### Description

This PR updates the linux distro for travis to xenial

Reason: failing `sudo apt-get update`: https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728/13

### Submission Checklist :pencil:

- [x] Update travis linux distro to xenial
