### PR TITLE
Add Hot/Cold Wallet Contract and Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,12 @@ before_install:
   - sudo apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libudev-dev
   - sudo apt-add-repository ppa:bitcoin/bitcoin -y
   - sudo apt-get update
-  - sudo apt-get install bitcoind -y
-apt_packages:
-  - bitcoind
+  - wget https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz && cat bitcoin-0.17.1-x86_64-linux-gnu.tar.gz| gzip -d | tar -xv
 
 before_script:
   - yarn global add ganache-cli
   - mkdir -p /home/travis/.bitcoin && cp bitcoin.conf /home/travis/.bitcoin/bitcoin.conf
-  - bitcoind -reindex -txindex -regtest -daemon -rpcport=18443 -rpcuser=bitcoin -rpcpassword=local321 -deprecatedrpc=signrawtransaction
+  - ./bitcoin-0.17.1/bin/bitcoind -reindex -txindex -regtest -daemon -rpcport=18443 -rpcuser=bitcoin -rpcpassword=local321 -deprecatedrpc=signrawtransaction
   - CI=false ganache-cli -k petersburg > /dev/null &
   - export NODE_OPTIONS="--max-old-space-size=8192"
 

--- a/contracts/FundsInterface.sol
+++ b/contracts/FundsInterface.sol
@@ -6,4 +6,6 @@ interface FundsInterface {
     function deposit(bytes32, uint256) external;
     function decreaseTotalBorrow(uint256) external;
     function calcGlobalInterest() external;
+    function withdraw(bytes32 fund, uint256 amount_) external;
+    function withdrawTo(bytes32 fund, uint256 amount_, address recipient_) external;
 }

--- a/contracts/HotColdWallet.sol
+++ b/contracts/HotColdWallet.sol
@@ -1,5 +1,9 @@
 pragma solidity 0.5.10;
 
+/**
+ * @title Atomic Loans Hot Cold Wallet Contract
+ * @author Atomic Loans
+ */
 contract HotColdWallet {
     address funds;
     address loans;
@@ -7,6 +11,14 @@ contract HotColdWallet {
     address public cold;
     address public hot;
 
+    /**
+     * @notice Construct a new HotColdWallet contract
+     * @param funds_ The address of the funds contract
+     * @param loans_ The address of the loans contract
+     * @param sales_ The address of the sales contract
+     * @param hot_ The address of the hot wallet
+     * @param data Transaction data for creating fund
+     */
     constructor (address funds_, address loans_, address sales_, address hot_, bytes memory data) public {
         funds = funds_;
         loans = loans_;
@@ -18,28 +30,49 @@ contract HotColdWallet {
         }
     }
 
+    /**
+     * @notice Determine whether transaction data is for Funds request function
+     * @param data Transaction data
+     * @return Whether the transaction data is for Funds request function
+     */
     function isRequest(bytes memory data) private pure returns (bool) {
         return data[0] == hex"f5" && data[1] == hex"9b" && data[2] == hex"f2" && data[3] == hex"73";
     }
 
+    /**
+     * @notice Call function in the Funds contract
+     * @param data Transaction data
+     */
     function callFunds(bytes memory data) public {
         require(msg.sender == cold || (isRequest(data) && msg.sender == hot), "callFunds: Must be cold wallet or requesting with hot wallet");
         (bool success, bytes memory returnData) = funds.call.value(0)(data);
         require(success, string(returnData));
     }
 
+    /**
+     * @notice Call function in the Loans contract
+     * @param data Transaction data
+     */
     function callLoans(bytes calldata data) external {
         require(msg.sender == cold || msg.sender == hot, "callLoans: Must be hot or cold wallet");
         (bool success, bytes memory returnData) = loans.call.value(0)(data);
         require(success, string(returnData));
     }
 
+    /**
+     * @notice Call function in the Sales contract
+     * @param data Transaction data
+     */
     function callSales(bytes calldata data) external {
         require(msg.sender == cold || msg.sender == hot, "callSales: Must be hot or cold wallet");
         (bool success, bytes memory returnData) = sales.call.value(0)(data);
         require(success, string(returnData));
     }
 
+    /**
+     * @notice Change hot wallet address
+     * @param newHot_ Address of new hot wallet
+     */
     function changeHot(address newHot_) external {
         require(msg.sender == cold, "changeHot: Must be cold wallet");
         require(newHot_ != address(0), "changeHot: New hot address cannot be null");

--- a/contracts/HotColdWallet.sol
+++ b/contracts/HotColdWallet.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.5.10;
+
+contract HotColdWallet {
+    address funds;
+    address loans;
+    address sales;
+    address public cold;
+    address public hot;
+
+    constructor (address funds_, address loans_, address sales_, address hot_, bytes memory data) public {
+        funds = funds_;
+        loans = loans_;
+        sales = sales_;
+        cold = msg.sender;
+        hot = hot_;
+        if (data.length > 0) {
+            callFunds(data);
+        }
+    }
+
+    function isRequest(bytes memory data) private pure returns (bool) {
+        return data[0] == hex"f5" && data[1] == hex"9b" && data[2] == hex"f2" && data[3] == hex"73";
+    }
+
+    function callFunds(bytes memory data) public {
+        require(msg.sender == cold || (isRequest(data) && msg.sender == hot), "callFunds: Must be cold wallet or requesting with hot wallet");
+        (bool success, bytes memory returnData) = funds.call.value(0)(data);
+        require(success, string(returnData));
+    }
+
+    function callLoans(bytes calldata data) external {
+        require(msg.sender == cold || msg.sender == hot, "callLoans: Must be hot or cold wallet");
+        (bool success, bytes memory returnData) = loans.call.value(0)(data);
+        require(success, string(returnData));
+    }
+
+    function callSales(bytes calldata data) external {
+        require(msg.sender == cold || msg.sender == hot, "callSales: Must be hot or cold wallet");
+        (bool success, bytes memory returnData) = sales.call.value(0)(data);
+        require(success, string(returnData));
+    }
+
+    function changeHot(address newHot_) external {
+        require(msg.sender == cold, "changeHot: Must be cold wallet");
+        require(newHot_ != address(0), "changeHot: New hot address cannot be null");
+        hot = newHot_;
+    }
+}

--- a/contracts/HotColdWallet.sol
+++ b/contracts/HotColdWallet.sol
@@ -23,6 +23,7 @@ contract HotColdWallet {
         require(funds_ != address(0), "constructor: Funds address cannot be null");
         require(loans_ != address(0), "constructor: Loans address cannot be null");
         require(sales_ != address(0), "constructor: Sales address cannot be null");
+        require(hot_ != address(0), "constructor: Hot address cannot be null");
         funds = funds_;
         loans = loans_;
         sales = sales_;
@@ -77,7 +78,7 @@ contract HotColdWallet {
     function changeHot(address newHot_) external {
         require(msg.sender == cold, "changeHot: Must be cold wallet");
         require(newHot_ != address(0), "changeHot: New hot address cannot be null");
-        require(newHot_ == hot, "changeHot: Hot is already is already new hot");
+        require(newHot_ != hot, "changeHot: Hot is already new hot");
         hot = newHot_;
     }
 }

--- a/contracts/HotColdWallet.sol
+++ b/contracts/HotColdWallet.sol
@@ -20,22 +20,23 @@ contract HotColdWallet {
      * @param data Transaction data for creating fund
      */
     constructor (address funds_, address loans_, address sales_, address hot_, bytes memory data) public {
+        require(funds_ != address(0), "constructor: Funds address cannot be null");
+        require(loans_ != address(0), "constructor: Loans address cannot be null");
+        require(sales_ != address(0), "constructor: Sales address cannot be null");
         funds = funds_;
         loans = loans_;
         sales = sales_;
         cold = msg.sender;
         hot = hot_;
-        if (data.length > 0) {
-            callFunds(data);
-        }
     }
 
     /**
-     * @notice Determine whether transaction data is for Funds request function
+     * @notice Determine whether transaction data is for Funds.request function
      * @param data Transaction data
      * @return Whether the transaction data is for Funds request function
      */
     function isRequest(bytes memory data) private pure returns (bool) {
+        require(data.length > 4);
         return data[0] == hex"f5" && data[1] == hex"9b" && data[2] == hex"f2" && data[3] == hex"73";
     }
 
@@ -76,6 +77,7 @@ contract HotColdWallet {
     function changeHot(address newHot_) external {
         require(msg.sender == cold, "changeHot: Must be cold wallet");
         require(newHot_ != address(0), "changeHot: New hot address cannot be null");
+        require(newHot_ == hot, "changeHot: Hot is already is already new hot");
         hot = newHot_;
     }
 }

--- a/contracts/HotColdWallet.sol
+++ b/contracts/HotColdWallet.sol
@@ -5,9 +5,9 @@ pragma solidity 0.5.10;
  * @author Atomic Loans
  */
 contract HotColdWallet {
-    address funds;
-    address loans;
-    address sales;
+    address public funds;
+    address public loans;
+    address public sales;
     address public cold;
     address public hot;
 
@@ -29,6 +29,9 @@ contract HotColdWallet {
         sales = sales_;
         cold = msg.sender;
         hot = hot_;
+        if (data.length > 0) {
+            callFunds(data);
+        }
     }
 
     /**
@@ -37,7 +40,7 @@ contract HotColdWallet {
      * @return Whether the transaction data is for Funds request function
      */
     function isRequest(bytes memory data) private pure returns (bool) {
-        require(data.length > 4);
+        require(data.length > 4, "isRequest: data length must be at least 4");
         return data[0] == hex"f5" && data[1] == hex"9b" && data[2] == hex"f2" && data[3] == hex"73";
     }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -24,6 +24,8 @@ var MakerMedianizer = artifacts.require('./_MakerMedianizer.sol')
 
 var ALCompound = artifacts.require('./ALCompound.sol')
 
+var HotColdWallet = artifacts.require('./HotColdWallet.sol')
+
 var fs = require('fs')
 
 var isCI = require('is-ci')
@@ -162,6 +164,8 @@ module.exports = function(deployer, network, accounts) {
     await usdcLoans.setCollateral(usdcCollateral.address)
 
     await deployer.deploy(ALCompound, comptroller.address) // LOCAL
+
+    await deployer.deploy(HotColdWallet, funds.address, loans.address, sales.address, accounts[1], '0x') // LOCAL
 
     console.info(`DAI_ADDRESS=${dai.address}`)
     console.info(`USDC_ADDRESS=${usdc.address}`)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -198,6 +198,16 @@ module.exports = function(deployer, network, accounts) {
     console.info(`  "ONDEMANDSPV": "${onDemandSpv.address}"`)
     console.info('}')
 
+    console.info('==================================')
+
+    console.info('{')
+    console.info(`  funds: '${funds.address}',`)
+    console.info(`  loans: '${loans.address}',`)
+    console.info(`  sales: '${sales.address}',`)
+    console.info(`  collateral: '${collateral.address}',`)
+    console.info(`  p2wsh: '${p2wsh.address}',`)
+    console.info('}')
+
     const contractAddresses = {
         "DAI": dai.address,
         "USDC": usdc.address,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:interest_decrease": "truffle test ./test/interestDecrease.js",
     "test:spv": "truffle test ./test/spv.js",
     "test:p2wsh": "truffle test ./test/p2wsh.js",
+    "test:hot_cold_wallet": "truffle test ./test/hotColdWallet.js",
     "coverage": "truffle run coverage",
     "build-contracts": "sol-merger \"./contracts/*.sol\" ./build"
   },

--- a/test/hotColdWallet.js
+++ b/test/hotColdWallet.js
@@ -1,0 +1,471 @@
+const { BigNumber: BN } = require('bignumber.js')
+const toSecs = require('@mblackmblack/to-seconds')
+const { time, expectRevert } = require('openzeppelin-test-helpers')
+const { ensure0x } = require('@liquality/ethereum-utils')
+const { sha256 } = require('@liquality/crypto')
+
+const Funds = artifacts.require('./Funds.sol')
+const Loans = artifacts.require('./Loans.sol')
+const Sales = artifacts.require('./Sales.sol')
+const HotColdWallet = artifacts.require('./HotColdWallet.sol')
+const ExampleCoin = artifacts.require("./ExampleDaiCoin.sol")
+const utils = require('./helpers/Utils.js')
+
+const { numToBytes32 } = utils;
+
+const { toWei } = web3.utils
+
+const BTC_TO_SAT = 10 ** 8
+const YEAR_IN_SECONDS = BN(31536000)
+const loanReq = 25
+const loanRat = 2
+const btcPrice = '9340.23'
+const col = Math.round(((loanReq * loanRat) / btcPrice) * BTC_TO_SAT)
+
+const borpubk = '02b4c50d2b6bdc9f45b9d705eeca37e811dfdeb7365bf42f82222f7a4a89868703'
+const lendpubk = '03dc23d80e1cf6feadf464406e299ac7fec9ea13c51dfd9abd970758bf33d89bb6'
+const arbiterpubk = '02688ce4b6ca876d3e0451e6059c34df4325745c1f7299ebc108812032106eaa32'
+const liquidatorpbkh = '7e18e6193db71abb00b70b102677675c27115871'
+
+let lendSecs = []
+let lendSechs = []
+for (let i = 0; i < 4; i++) {
+  let sec = sha256(Math.random().toString())
+  lendSecs.push(ensure0x(sec))
+  lendSechs.push(ensure0x(sha256(sec)))
+}
+
+let borSecs = []
+let borSechs = []
+for (let i = 0; i < 4; i++) {
+  let sec = sha256(Math.random().toString())
+  borSecs.push(ensure0x(sec))
+  borSechs.push(ensure0x(sha256(sec)))
+}
+
+let arbiterSecs = []
+let arbiterSechs = []
+for (let i = 0; i < 4; i++) {
+  let sec = sha256(Math.random().toString())
+  arbiterSecs.push(ensure0x(sec))
+  arbiterSechs.push(ensure0x(sha256(sec)))
+}
+
+let liquidatorSecs = []
+let liquidatorSechs = []
+for (let i = 0; i < 4; i++) {
+  let sec = sha256(Math.random().toString())
+  liquidatorSecs.push(ensure0x(sec))
+  liquidatorSechs.push(ensure0x(sha256(sec)))
+}
+
+async function increaseTime(seconds) {
+  await time.increase(seconds)
+}
+
+async function approveAndTransfer(token, spender, contract, amount) {
+  await token.transfer(spender, amount)
+  await token.approve(contract.address, amount, { from: spender })
+}
+
+contract('HotColdWallet', accounts => {
+  const deployer = accounts[0]
+  const hotWallet = accounts[1]
+  const hotWallet2 = accounts[2]
+  const otherWallet = accounts[3]
+  const arbiter = accounts[4]
+  const borrower = accounts[5]
+  const liquidator = accounts[6]
+  
+  beforeEach(async function () {
+    this.funds = await Funds.deployed()
+    this.loans = await Loans.deployed()
+    this.sales = await Sales.deployed()
+    this.token = await ExampleCoin.deployed()
+    this.hotColdWallet = await HotColdWallet.deployed()
+  })
+
+  describe('Constructor', function() {
+    it('should allow creation of fund', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+    })
+  })
+
+  describe('callFunds', function() {
+    it('should succeed if cold wallet', async function() {
+      const newPubKey = '0x02394be3c0449eca5542edcdbe9a55a9eb52dd72c5c70d40cfe15b7bc3f34df965'
+
+      const setPubKeyTxData = this.funds.contract.methods.setPubKey(newPubKey).encodeABI()
+
+      const pubKeyBefore = await this.funds.pubKeys.call(this.hotColdWallet.address)
+
+      await this.hotColdWallet.callFunds(setPubKeyTxData)
+
+      const pubKeyAfter = await this.funds.pubKeys.call(this.hotColdWallet.address)
+
+      expect(pubKeyBefore).to.equal(null)
+      expect(pubKeyAfter).to.equal(newPubKey)
+    })
+
+    it('should succeed if hot wallet and requesting loan', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      const hotColdWallet = await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+
+      const fund = numToBytes32(fundIndexAfter)
+
+      await this.funds.generate(arbiterSechs, { from: arbiter })
+
+      await this.token.approve(this.funds.address, toWei('100', 'ether'))
+      await this.funds.deposit(fund, toWei('100', 'ether'))
+
+      const loanParams = [
+        fund,
+        borrower,
+        toWei(loanReq.toString(), 'ether'),
+        col,
+        toSecs({days: 2}),
+        ~~(Date.now() / 1000),
+        [ ...borSechs, ...lendSechs ],
+        ensure0x(borpubk),
+        ensure0x(lendpubk)
+      ]
+
+      const requestFundTxData = this.funds.contract.methods.request(...loanParams).encodeABI()
+
+      const loanIndexBefore = await this.loans.loanIndex.call()
+
+      await hotColdWallet.callFunds(requestFundTxData, { from: hotWallet })
+
+      const loanIndexAfter = await this.loans.loanIndex.call()
+
+      expect(BN(loanIndexBefore).plus(1).toFixed()).to.equal(BN(loanIndexAfter).toFixed())
+    })
+
+    it('should fail if hot wallet', async function() {
+      const newPubKey = '0x02394be3c0449eca5542edcdbe9a55a9eb52dd72c5c70d40cfe15b7bc3f34df965'
+
+      const setPubKeyTxData = this.funds.contract.methods.setPubKey(newPubKey).encodeABI()
+
+      await expectRevert(this.hotColdWallet.callFunds(setPubKeyTxData, { from: hotWallet }), 'VM Exception while processing transaction: revert')
+    })
+  })
+
+  describe('callLoans', function() {
+    it('should succeed if called by hot wallet', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      const hotColdWallet = await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+
+      const fund = numToBytes32(fundIndexAfter)
+
+      await this.funds.generate(arbiterSechs, { from: arbiter })
+
+      await this.token.approve(this.funds.address, toWei('100', 'ether'))
+      await this.funds.deposit(fund, toWei('100', 'ether'))
+
+      const loanParams = [
+        fund,
+        borrower,
+        toWei(loanReq.toString(), 'ether'),
+        col,
+        toSecs({days: 2}),
+        ~~(Date.now() / 1000),
+        [ ...borSechs, ...lendSechs ],
+        ensure0x(borpubk),
+        ensure0x(lendpubk)
+      ]
+
+      const requestFundTxData = this.funds.contract.methods.request(...loanParams).encodeABI()
+
+      const loanIndexBefore = await this.loans.loanIndex.call()
+
+      await hotColdWallet.callFunds(requestFundTxData, { from: hotWallet })
+
+      const loanIndexAfter = await this.loans.loanIndex.call()
+
+      const loan = numToBytes32(loanIndexAfter)
+
+      expect(BN(loanIndexBefore).plus(1).toFixed()).to.equal(BN(loanIndexAfter).toFixed())
+
+      const approveLoanTxData = this.loans.contract.methods.approve(loan).encodeABI()
+
+      await hotColdWallet.callLoans(approveLoanTxData, { from: hotWallet })
+
+      const { approved } = await this.loans.bools.call(loan)
+      expect(approved).to.equal(true)
+    })
+
+    it('should fail if not hot or cold wallet', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      const hotColdWallet = await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+
+      const fund = numToBytes32(fundIndexAfter)
+
+      await this.funds.generate(arbiterSechs, { from: arbiter })
+
+      await this.token.approve(this.funds.address, toWei('100', 'ether'))
+      await this.funds.deposit(fund, toWei('100', 'ether'))
+
+      const loanParams = [
+        fund,
+        borrower,
+        toWei(loanReq.toString(), 'ether'),
+        col,
+        toSecs({days: 2}),
+        ~~(Date.now() / 1000),
+        [ ...borSechs, ...lendSechs ],
+        ensure0x(borpubk),
+        ensure0x(lendpubk)
+      ]
+
+      const requestFundTxData = this.funds.contract.methods.request(...loanParams).encodeABI()
+
+      const loanIndexBefore = await this.loans.loanIndex.call()
+
+      await hotColdWallet.callFunds(requestFundTxData, { from: hotWallet })
+
+      const loanIndexAfter = await this.loans.loanIndex.call()
+
+      const loan = numToBytes32(loanIndexAfter)
+
+      expect(BN(loanIndexBefore).plus(1).toFixed()).to.equal(BN(loanIndexAfter).toFixed())
+
+      const approveLoanTxData = this.loans.contract.methods.approve(loan).encodeABI()
+
+      await expectRevert(hotColdWallet.callLoans(approveLoanTxData, { from: otherWallet }), 'VM Exception while processing transaction: revert')
+    })
+  })
+
+  describe('callSales', function() {
+    it('should succeed if called by hot wallet', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      const hotColdWallet = await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+
+      const fund = numToBytes32(fundIndexAfter)
+
+      await this.funds.generate(arbiterSechs, { from: arbiter })
+
+      await this.token.approve(this.funds.address, toWei('100', 'ether'))
+      await this.funds.deposit(fund, toWei('100', 'ether'))
+
+      const loanParams = [
+        fund,
+        borrower,
+        toWei(loanReq.toString(), 'ether'),
+        col,
+        toSecs({days: 1}),
+        ~~(Date.now() / 1000),
+        [ ...borSechs, ...lendSechs ],
+        ensure0x(borpubk),
+        ensure0x(lendpubk)
+      ]
+
+      const requestFundTxData = this.funds.contract.methods.request(...loanParams).encodeABI()
+
+      const loanIndexBefore = await this.loans.loanIndex.call()
+
+      await hotColdWallet.callFunds(requestFundTxData, { from: hotWallet })
+
+      const loanIndexAfter = await this.loans.loanIndex.call()
+
+      const loan = numToBytes32(loanIndexAfter)
+
+      expect(BN(loanIndexBefore).plus(1).toFixed()).to.equal(BN(loanIndexAfter).toFixed())
+
+      const approveLoanTxData = this.loans.contract.methods.approve(loan).encodeABI()
+
+      await hotColdWallet.callLoans(approveLoanTxData, { from: hotWallet })
+
+      await this.loans.withdraw(loan, borSecs[0])
+
+      await increaseTime(toSecs({days: 1, minutes: 2}))
+
+      await approveAndTransfer(this.token, liquidator, this.loans, toWei('100', 'ether'))
+
+      const saleIndexBefore = await this.sales.saleIndex.call()
+
+      await this.loans.liquidate(loan, liquidatorSechs[0], ensure0x(liquidatorpbkh), { from: liquidator })
+
+      const saleIndexAfter = await this.sales.saleIndex.call()
+
+      const sale = numToBytes32(saleIndexAfter)
+
+      const provideSecretSaleTxData = this.sales.contract.methods.provideSecret(sale, liquidatorSecs[0]).encodeABI()
+
+      await hotColdWallet.callSales(provideSecretSaleTxData, { from: hotWallet })
+
+      const { secretD } = await this.sales.secretHashes.call(sale)
+
+      expect(secretD).to.equal(liquidatorSecs[0])
+    })
+
+    it('should fail if not hot or cold wallet', async function() {
+      const fundParams = [
+        toSecs({days: 50}),
+        YEAR_IN_SECONDS.times(2).plus(Math.floor(Date.now() / 1000)).toFixed(),
+        arbiter,
+        false,
+        0
+      ]
+
+      const createFundTxData = this.funds.contract.methods.create(...fundParams).encodeABI()
+
+      const fundIndexBefore = await this.funds.fundIndex.call()
+
+      const hotColdWallet = await HotColdWallet.new(this.funds.address, this.loans.address, this.sales.address, hotWallet, createFundTxData)
+
+      const fundIndexAfter = await this.funds.fundIndex.call()
+
+      expect(BN(fundIndexBefore).plus(1).toFixed()).to.equal(BN(fundIndexAfter).toFixed())
+
+      const fund = numToBytes32(fundIndexAfter)
+
+      await this.funds.generate(arbiterSechs, { from: arbiter })
+
+      await this.token.approve(this.funds.address, toWei('100', 'ether'))
+      await this.funds.deposit(fund, toWei('100', 'ether'))
+
+      const loanParams = [
+        fund,
+        borrower,
+        toWei(loanReq.toString(), 'ether'),
+        col,
+        toSecs({days: 1}),
+        ~~(Date.now() / 1000),
+        [ ...borSechs, ...lendSechs ],
+        ensure0x(borpubk),
+        ensure0x(lendpubk)
+      ]
+
+      const requestFundTxData = this.funds.contract.methods.request(...loanParams).encodeABI()
+
+      const loanIndexBefore = await this.loans.loanIndex.call()
+
+      await hotColdWallet.callFunds(requestFundTxData, { from: hotWallet })
+
+      const loanIndexAfter = await this.loans.loanIndex.call()
+
+      const loan = numToBytes32(loanIndexAfter)
+
+      expect(BN(loanIndexBefore).plus(1).toFixed()).to.equal(BN(loanIndexAfter).toFixed())
+
+      const approveLoanTxData = this.loans.contract.methods.approve(loan).encodeABI()
+
+      await hotColdWallet.callLoans(approveLoanTxData, { from: hotWallet })
+
+      await this.loans.withdraw(loan, borSecs[0])
+
+      await increaseTime(toSecs({days: 1, minutes: 2}))
+
+      await approveAndTransfer(this.token, liquidator, this.loans, toWei('100', 'ether'))
+
+      const saleIndexBefore = await this.sales.saleIndex.call()
+
+      await this.loans.liquidate(loan, liquidatorSechs[0], ensure0x(liquidatorpbkh), { from: liquidator })
+
+      const saleIndexAfter = await this.sales.saleIndex.call()
+
+      const sale = numToBytes32(saleIndexAfter)
+
+      const provideSecretSaleTxData = this.sales.contract.methods.provideSecret(sale, liquidatorSecs[0]).encodeABI()
+
+      await expectRevert(hotColdWallet.callSales(provideSecretSaleTxData, { from: otherWallet }), 'VM Exception while processing transaction: revert')
+    })
+  })
+
+  describe('ChangeHot', function() {
+    it('should succeed in changing hot wallet if from cold wallet', async function() {
+      const hotBefore = await this.hotColdWallet.hot.call()
+
+      await this.hotColdWallet.changeHot(hotWallet2)
+
+      const hotAfter = await this.hotColdWallet.hot.call()
+
+      expect(hotBefore).to.equal(hotWallet)
+      expect(hotAfter).to.equal(hotWallet2)
+    })
+
+    it('should fail if not cold wallet', async function() {
+      await expectRevert(this.hotColdWallet.changeHot(hotWallet2, { from: hotWallet }), 'VM Exception while processing transaction: revert')
+    })
+
+    it('should fail if new hot address is null', async function() {
+      await expectRevert(this.hotColdWallet.changeHot('0x0000000000000000000000000000000000000000'), 'VM Exception while processing transaction: revert')
+    })
+  })
+})


### PR DESCRIPTION
### Description

This PR adds Hot/Cold wallet contract and tests. The purpose of this is to allow an [agent](https://github.com/atomicloans/agent) to run with a Hot wallet, that is only able to make calls to the `Loans` and `Sales` contract (as well as `Funds.request`), while the Cold wallet is able to make all calls, including `Funds.withdraw`, as well as change the Hot wallet address. The basic idea, is that the Cold wallet can withdraw funds, while the Hot wallet maintains existing debt agreements. 

### Submission Checklist :pencil:

- [x] Add Hot/Cold Wallet Contract
- [x] Add tests for Hot/Cold Wallet Contract
- [x] Add natspec for Hot/Cold Wallet Contract
